### PR TITLE
Update pi-synthetic-provider for pi 0.64 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "^2.3.5",
-        "@mariozechner/pi-ai": "^0.62.0",
-        "@mariozechner/pi-coding-agent": "^0.62.0",
+        "@mariozechner/pi-ai": "^0.64.0",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
         "@sinclair/typebox": "^0.34.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0",
@@ -1868,21 +1868,21 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.62.0.tgz",
-      "integrity": "sha512-SBjqgDrgKOaC+IGzFGB3jXQErv9H1QMYnWFvUg6ra6dG0ZgWFBUZb6unidngWLsmaxSDWes6KeKiVFMsr2VSEQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.64.0.tgz",
+      "integrity": "sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.62.0"
+        "@mariozechner/pi-ai": "^0.64.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.62.0.tgz",
-      "integrity": "sha512-mJgryZ5RgBQG++tiETMtCQQJoH2MAhKetCfqI98NMvGydu7L9x2qC2JekQlRaAgIlTgv4MRH1UXHMEs4UweE/Q==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.64.0.tgz",
+      "integrity": "sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -1907,16 +1907,17 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.62.0.tgz",
-      "integrity": "sha512-f1NnExqsHuA6w8UVlBtPsvTBhdkMc0h1JD9SzGCdWTLou5GHJr2JIP6DlwV9IKWAnM+sAelaoFez+14wLP2zOQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.64.0.tgz",
+      "integrity": "sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g==",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.62.0",
-        "@mariozechner/pi-ai": "^0.62.0",
-        "@mariozechner/pi-tui": "^0.62.0",
+        "@mariozechner/pi-agent-core": "^0.64.0",
+        "@mariozechner/pi-ai": "^0.64.0",
+        "@mariozechner/pi-tui": "^0.64.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
+        "ajv": "^8.17.1",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
@@ -1970,9 +1971,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.62.0.tgz",
-      "integrity": "sha512-/At11PPe8l319MnUoK4wN5L/uVCU6bDdiIUzH8Ez0stOkjSF6isRXScZ+RMM+6iCKsD4muBTX8Cmcif+3/UWHA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.64.0.tgz",
+      "integrity": "sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -5659,7 +5660,7 @@
     },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": "*"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.5",
-    "@mariozechner/pi-ai": "^0.62.0",
-    "@mariozechner/pi-coding-agent": "^0.62.0",
+    "@mariozechner/pi-ai": "^0.64.0",
+    "@mariozechner/pi-coding-agent": "^0.64.0",
     "@sinclair/typebox": "^0.34.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.5.0",

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-03-29
+
+### Changed
+- Updated the `session_start` live provider refresh path to use `pi.registerProvider(...)`, keeping Synthetic model refresh aligned with current pi runtime behavior.
+- Updated `/synthetic-quota` to recognize Synthetic's hybrid and enhanced quota payloads, prioritizing rolling five-hour and weekly token limits ahead of search usage for newer accounts.
+- Increased quota percentage precision in the overlay from one decimal place to two decimals for closer parity with the Synthetic website.
+
+### Fixed
+- Hid empty zero-limit tool-call buckets such as `freeToolCalls: { limit: 0, requests: 0 }` when the feature is not enabled.
+- Fixed `/synthetic-quota` overlay dismissal so `Esc`, standard `Enter`, and keypad `Enter` all close the window consistently across terminal input modes.
+
+### Docs
+- Documented `/synthetic-quota` in the package README and added notes covering newer Synthetic quota systems and current pi compatibility expectations.
+
 ## [1.1.8] - 2026-02-25
 
 ### Added

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -68,6 +68,7 @@ pi --model synthetic
 ### Extension Command
 
 - `/synthetic-models` -- display all available models with pricing and capabilities
+- `/synthetic-quota` -- display current Synthetic API quota usage, including rolling five-hour, weekly token, and search limits when available
 
 ## Available Models
 
@@ -95,6 +96,11 @@ When multiple sources are configured, pi checks in this order:
 
 - pi v0.51.0 or later
 - A Synthetic API key from [synthetic.new](https://synthetic.new)
+
+## Notes
+
+- On newer Synthetic accounts, `/synthetic-quota` prefers the current rolling five-hour and weekly token limits over the legacy subscription bucket, while still showing search usage when present.
+- The provider refresh path is compatible with current pi releases that expect dynamic provider updates to go through `pi.registerProvider(...)`.
 
 ## Uninstall
 

--- a/packages/pi-synthetic-provider/__tests__/commands.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/commands.test.ts
@@ -19,7 +19,9 @@ interface MockSelectList {
 
 let lastSelectList: MockSelectList | null = null;
 
-vi.mock("@mariozechner/pi-tui", () => {
+vi.mock("@mariozechner/pi-tui", async (importOriginal) => {
+	const original = await importOriginal<typeof import("@mariozechner/pi-tui")>();
+
 	class MockBox {
 		addChild = vi.fn();
 		render = vi.fn().mockReturnValue([]);
@@ -47,6 +49,7 @@ vi.mock("@mariozechner/pi-tui", () => {
 		}
 	}
 	return {
+		...original,
 		Box: MockBox,
 		Container: MockContainer,
 		Spacer: MockSpacer,
@@ -460,6 +463,89 @@ describe("/synthetic-quota command", () => {
 		expect(doneFn).not.toHaveBeenCalled();
 		renderer.handleInput("\r"); // Enter
 		expect(doneFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("renderer handles keypad Enter to close", async () => {
+		const mockPi = createMockPi();
+		registerSyntheticQuotaCommand(mockPi as unknown as ExtensionAPI);
+		const handler = getHandler(mockPi, "synthetic-quota");
+
+		const mockResponse = {
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				subscription: { limit: 100, requests: 10, renewsAt: new Date(Date.now() + 1800_000).toISOString() },
+			}),
+		};
+		vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+		const { customFn, getCapturedRenderer, doneFn } = createCapturingCustomMock();
+		const ctx = createMockCtx({}, customFn);
+		await handler("", ctx);
+
+		const renderer = getCapturedRenderer();
+		expect(doneFn).not.toHaveBeenCalled();
+		renderer.handleInput("\x1bOM"); // keypad Enter in some terminals
+		expect(doneFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("renderer handles normalized Escape variants to close", async () => {
+		const mockPi = createMockPi();
+		registerSyntheticQuotaCommand(mockPi as unknown as ExtensionAPI);
+		const handler = getHandler(mockPi, "synthetic-quota");
+
+		const mockResponse = {
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				subscription: { limit: 100, requests: 10, renewsAt: new Date(Date.now() + 1800_000).toISOString() },
+			}),
+		};
+		vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+		const { customFn, getCapturedRenderer, doneFn } = createCapturingCustomMock();
+		const ctx = createMockCtx({}, customFn);
+		await handler("", ctx);
+
+		const renderer = getCapturedRenderer();
+		expect(doneFn).not.toHaveBeenCalled();
+		renderer.handleInput("\x1b[27;1;27~"); // xterm modifyOtherKeys Escape
+		expect(doneFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens overlay for hybrid legacy + enhanced quota responses", async () => {
+		const mockPi = createMockPi();
+		registerSyntheticQuotaCommand(mockPi as unknown as ExtensionAPI);
+		const handler = getHandler(mockPi, "synthetic-quota");
+
+		const mockResponse = {
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				subscription: { limit: 600, requests: 0, renewsAt: new Date(Date.now() + 3600_000).toISOString() },
+				search: {
+					hourly: { limit: 250, requests: 0, renewsAt: new Date(Date.now() + 1800_000).toISOString() },
+				},
+				freeToolCalls: { limit: 0, requests: 0, renewsAt: new Date(Date.now() + 86_400_000).toISOString() },
+				weeklyTokenLimit: {
+					nextRegenAt: new Date(Date.now() + 12 * 3600_000).toISOString(),
+					percentRemaining: 99.9,
+				},
+				rollingFiveHourLimit: {
+					nextTickAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+					tickPercent: 0.05,
+					remaining: 600,
+					max: 600,
+					limited: false,
+				},
+			}),
+		};
+		vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+		const { customFn, getCapturedRenderer } = createCapturingCustomMock();
+		const ctx = createMockCtx({}, customFn);
+		await handler("", ctx);
+
+		expect(ctx.ui.custom).toHaveBeenCalledTimes(1);
+		const renderer = getCapturedRenderer();
+		expect(() => renderer.render(80)).not.toThrow();
 	});
 
 	it("shows error notification when quota fetch fails", async () => {

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -3,8 +3,11 @@ import {
 	buildProgressBar,
 	formatTimeRemaining,
 	getFallbackModels,
+	getQuotaSystemLabel,
 	getUsageColor,
+	hasVisibleQuotaBucket,
 	parsePrice,
+	shouldDisplaySubscriptionQuota,
 } from "../extensions/index.js";
 
 describe("pi-synthetic-provider helpers", () => {
@@ -98,6 +101,109 @@ describe("quota helpers", () => {
 		it("returns '< 1m' for very short durations", () => {
 			const nearFuture = new Date(Date.now() + 30_000).toISOString();
 			expect(formatTimeRemaining(nearFuture)).toBe("< 1m");
+		});
+	});
+
+	describe("hasVisibleQuotaBucket", () => {
+		it("returns false for missing buckets", () => {
+			expect(hasVisibleQuotaBucket(undefined)).toBe(false);
+		});
+
+		it("returns false for disabled zero buckets", () => {
+			expect(
+				hasVisibleQuotaBucket({
+					limit: 0,
+					requests: 0,
+					renewsAt: new Date(Date.now() + 60_000).toISOString(),
+				}),
+			).toBe(false);
+		});
+
+		it("returns true when the bucket has a limit", () => {
+			expect(
+				hasVisibleQuotaBucket({
+					limit: 10,
+					requests: 0,
+					renewsAt: new Date(Date.now() + 60_000).toISOString(),
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe("getQuotaSystemLabel", () => {
+		it("detects classic quota systems", () => {
+			expect(
+				getQuotaSystemLabel({
+					subscription: {
+						limit: 100,
+						requests: 10,
+						renewsAt: new Date(Date.now() + 60_000).toISOString(),
+					},
+				}),
+			).toBe("Classic quota system");
+		});
+
+		it("detects enhanced quota systems", () => {
+			expect(
+				getQuotaSystemLabel({
+					weeklyTokenLimit: {
+						nextRegenAt: new Date(Date.now() + 60_000).toISOString(),
+						percentRemaining: 75,
+					},
+				}),
+			).toBe("Enhanced quota system");
+		});
+
+		it("detects hybrid quota systems", () => {
+			expect(
+				getQuotaSystemLabel({
+					subscription: {
+						limit: 100,
+						requests: 10,
+						renewsAt: new Date(Date.now() + 60_000).toISOString(),
+					},
+					rollingFiveHourLimit: {
+						nextTickAt: new Date(Date.now() + 60_000).toISOString(),
+						tickPercent: 0.05,
+						remaining: 90,
+						max: 100,
+						limited: false,
+					},
+				}),
+			).toBe("Hybrid quota system");
+		});
+	});
+
+	describe("shouldDisplaySubscriptionQuota", () => {
+		it("shows subscription quota for classic users", () => {
+			expect(
+				shouldDisplaySubscriptionQuota({
+					subscription: {
+						limit: 100,
+						requests: 10,
+						renewsAt: new Date(Date.now() + 60_000).toISOString(),
+					},
+				}),
+			).toBe(true);
+		});
+
+		it("hides subscription quota for hybrid users", () => {
+			expect(
+				shouldDisplaySubscriptionQuota({
+					subscription: {
+						limit: 600,
+						requests: 0,
+						renewsAt: new Date(Date.now() + 60_000).toISOString(),
+					},
+					rollingFiveHourLimit: {
+						nextTickAt: new Date(Date.now() + 60_000).toISOString(),
+						tickPercent: 0.05,
+						remaining: 600,
+						max: 600,
+						limited: false,
+					},
+				}),
+			).toBe(false);
 		});
 	});
 });

--- a/packages/pi-synthetic-provider/extensions/commands/synthetic-quota.ts
+++ b/packages/pi-synthetic-provider/extensions/commands/synthetic-quota.ts
@@ -4,10 +4,18 @@
  */
 
 import { DynamicBorder, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Box, Container, Spacer, Text } from "@mariozechner/pi-tui";
+import { Box, Container, matchesKey, Spacer, Text } from "@mariozechner/pi-tui";
 import { getSyntheticApiKey } from "../auth.js";
-import { buildProgressBar, fetchSyntheticQuota, formatTimeRemaining, getUsageColor } from "../quota.js";
-import type { QuotaBucket } from "../types.js";
+import {
+	buildProgressBar,
+	fetchSyntheticQuota,
+	formatTimeRemaining,
+	getQuotaSystemLabel,
+	getUsageColor,
+	hasVisibleQuotaBucket,
+	shouldDisplaySubscriptionQuota,
+} from "../quota.js";
+import type { QuotaBucket, RollingFiveHourLimit, WeeklyTokenLimit } from "../types.js";
 
 export function registerSyntheticQuotaCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("synthetic-quota", {
@@ -42,19 +50,32 @@ export function registerSyntheticQuotaCommand(pi: ExtensionAPI): void {
 						overlayRows = tui.terminal.rows;
 						overlayCols = tui.terminal.columns;
 
+						const quotaSystemLabel = getQuotaSystemLabel(quota);
+						const showSubscription = shouldDisplaySubscriptionQuota(quota);
 						// API has moved tool-call quota from `toolCallDiscounts` to `freeToolCalls`;
 						// keep both for backwards compatibility with older payloads.
-						const toolCallBucket = quota.toolCallDiscounts ?? quota.freeToolCalls;
+						const toolCallBucket = hasVisibleQuotaBucket(quota.toolCallDiscounts)
+							? quota.toolCallDiscounts
+							: hasVisibleQuotaBucket(quota.freeToolCalls)
+								? quota.freeToolCalls
+								: undefined;
+						const visibleSections = [
+							showSubscription,
+							Boolean(quota.rollingFiveHourLimit),
+							Boolean(quota.weeklyTokenLimit),
+							hasVisibleQuotaBucket(quota.search?.hourly),
+							Boolean(toolCallBucket),
+						].filter(Boolean).length;
 						// Count how many sections we'll render to estimate needed height
-						const bucketCount = [quota.subscription, toolCallBucket, quota.search?.hourly].filter(Boolean).length;
 						// Normal layout: ~7 lines/bucket + 3 separator lines between + 6 chrome
 						// Compact layout: ~3 lines/bucket + 1 separator line between + 4 chrome
-						const normalHeight = bucketCount * 7 + (bucketCount - 1) * 3 + 6;
+						const normalHeight = visibleSections * 7 + Math.max(0, visibleSections - 1) * 3 + 6;
 						const compact = overlayRows < 45 || normalHeight > overlayRows * 0.75;
 						const barWidth = compact ? 20 : BAR_WIDTH;
+						const formatPercent = (value: number) => `${value.toFixed(2)}%`;
 
 						const renderBucket = (label: string, bucket: QuotaBucket | undefined, icon: string): string[] => {
-							if (!bucket) return [];
+							if (!hasVisibleQuotaBucket(bucket)) return [];
 
 							const { bar, percent } = buildProgressBar(bucket.requests, bucket.limit, barWidth);
 							const color = getUsageColor(percent);
@@ -64,41 +85,115 @@ export function registerSyntheticQuotaCommand(pi: ExtensionAPI): void {
 							if (compact) {
 								return [
 									`${icon}  ${theme.fg("accent", theme.bold(label))}`,
-									`   ${theme.fg(color, bar)}  ${theme.fg(color, `${percent.toFixed(1)}%`)} used`,
-									`   ${theme.bold(String(bucket.requests))} / ${bucket.limit} req ${theme.fg("muted", "·")} ${theme.fg(remaining > 0 ? "success" : "error", remaining.toFixed(1))} left ${theme.fg("muted", "·")} resets ${theme.fg("accent", renewalStr)}`,
+									`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percent))} used`,
+									`   ${theme.bold(String(bucket.requests))} / ${bucket.limit} req ${theme.fg("muted", "·")} ${theme.fg(remaining > 0 ? "success" : "error", String(remaining))} left ${theme.fg("muted", "·")} resets ${theme.fg("accent", renewalStr)}`,
 								];
 							}
 
 							return [
 								`${icon}  ${theme.fg("accent", theme.bold(label))}`,
 								"",
-								`   ${theme.fg(color, bar)}  ${theme.fg(color, `${percent.toFixed(1)}%`)} used`,
+								`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percent))} used`,
 								"",
 								`   ${theme.fg("muted", "Used:")}     ${theme.bold(String(bucket.requests))} / ${bucket.limit} requests`,
-								`   ${theme.fg("muted", "Remaining:")} ${theme.fg(remaining > 0 ? "success" : "error", remaining.toFixed(1))} requests`,
+								`   ${theme.fg("muted", "Remaining:")} ${theme.fg(remaining > 0 ? "success" : "error", String(remaining))} requests`,
 								`   ${theme.fg("muted", "Resets in:")} ${theme.fg("accent", renewalStr)}`,
 							];
 						};
 
+						const renderWeeklyLimit = (label: string, weekly: WeeklyTokenLimit | undefined, icon: string): string[] => {
+							if (!weekly) return [];
+
+							const percentRemaining = Math.max(0, Math.min(weekly.percentRemaining, 100));
+							const percentUsed = 100 - percentRemaining;
+							const { bar } = buildProgressBar(percentUsed, 100, barWidth);
+							const color = getUsageColor(percentUsed);
+							const renewalStr = formatTimeRemaining(weekly.nextRegenAt);
+
+							if (compact) {
+								return [
+									`${icon}  ${theme.fg("accent", theme.bold(label))}`,
+									`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percentUsed))} used`,
+									`   ${theme.fg("success", formatPercent(percentRemaining))} remaining ${theme.fg("muted", "·")} regenerates ${theme.fg("accent", renewalStr)}`,
+								];
+							}
+
+							return [
+								`${icon}  ${theme.fg("accent", theme.bold(label))}`,
+								"",
+								`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percentUsed))} used`,
+								"",
+								`   ${theme.fg("muted", "Remaining:")} ${theme.fg("success", formatPercent(percentRemaining))}`,
+								`   ${theme.fg("muted", "Used:")}      ${theme.bold(formatPercent(percentUsed))}`,
+								`   ${theme.fg("muted", "Regens in:")} ${theme.fg("accent", renewalStr)}`,
+							];
+						};
+
+						const renderRollingLimit = (
+							label: string,
+							rolling: RollingFiveHourLimit | undefined,
+							icon: string,
+						): string[] => {
+							if (!rolling) return [];
+
+							const used = Math.max(0, rolling.max - rolling.remaining);
+							const { bar, percent } = buildProgressBar(used, rolling.max, barWidth);
+							const color = getUsageColor(percent);
+							const tickStr = formatTimeRemaining(rolling.nextTickAt);
+
+							if (compact) {
+								return [
+									`${icon}  ${theme.fg("accent", theme.bold(label))}`,
+									`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percent))} used`,
+									`   ${theme.bold(String(rolling.remaining))} / ${rolling.max} left ${theme.fg("muted", "·")} ${rolling.limited ? theme.fg("error", "limited now") : theme.fg("success", "available")} ${theme.fg("muted", "·")} ticks ${theme.fg("accent", tickStr)}`,
+								];
+							}
+
+							return [
+								`${icon}  ${theme.fg("accent", theme.bold(label))}`,
+								"",
+								`   ${theme.fg(color, bar)}  ${theme.fg(color, formatPercent(percent))} used`,
+								"",
+								`   ${theme.fg("muted", "Remaining:")} ${theme.bold(String(rolling.remaining))} / ${rolling.max}`,
+								`   ${theme.fg("muted", "Status:")}    ${rolling.limited ? theme.fg("error", "Limited") : theme.fg("success", "Available")}`,
+								`   ${theme.fg("muted", "Next tick:")} ${theme.fg("accent", tickStr)} (${formatPercent(rolling.tickPercent * 100)})`,
+							];
+						};
+
 						const sections: string[][] = [];
-						sections.push(renderBucket("Subscription", quota.subscription, "⚡"));
+						if (showSubscription) {
+							sections.push(renderBucket("Subscription", quota.subscription, "⚡"));
+						}
+						if (quota.rollingFiveHourLimit) {
+							sections.push(renderRollingLimit("Rolling 5h Limit", quota.rollingFiveHourLimit, "⏱"));
+						}
+						if (quota.weeklyTokenLimit) {
+							sections.push(renderWeeklyLimit("Weekly Token Limit", quota.weeklyTokenLimit, "🗓"));
+						}
+						if (hasVisibleQuotaBucket(quota.search?.hourly)) {
+							sections.push(renderBucket("Search (hourly)", quota.search.hourly, "🔍"));
+						}
 						if (toolCallBucket) {
 							const toolCallLabel = quota.toolCallDiscounts ? "Tool Call Discounts" : "Free Tool Calls";
 							sections.push(renderBucket(toolCallLabel, toolCallBucket, "🔧"));
-						}
-						if (quota.search?.hourly) {
-							sections.push(renderBucket("Search (hourly)", quota.search.hourly, "🔍"));
 						}
 
 						const container = new Container();
 						container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
 						container.addChild(new Text(theme.fg("accent", theme.bold("  Synthetic API Quota")), 1, 0));
 
-						if (!compact) {
-							container.addChild(
-								new Text(theme.fg("muted", "  Usage and limits for your Synthetic subscription"), 1, 0),
-							);
-						}
+						container.addChild(
+							new Text(
+								theme.fg(
+									"muted",
+									compact
+										? `  ${quotaSystemLabel}`
+										: `  ${quotaSystemLabel} · usage and limits for your Synthetic account`,
+								),
+								1,
+								0,
+							),
+						);
 
 						container.addChild(new DynamicBorder((s: string) => theme.fg("muted", s)));
 
@@ -133,7 +228,7 @@ export function registerSyntheticQuotaCommand(pi: ExtensionAPI): void {
 							render: (width) => panel.render(width),
 							invalidate: () => panel.invalidate(),
 							handleInput: (data) => {
-								if (data === "\x1b" || data === "\r" || data === "\n") {
+								if (matchesKey(data, "escape") || matchesKey(data, "enter") || matchesKey(data, "ctrl+c")) {
 									done(undefined);
 								}
 							},

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -61,7 +61,15 @@ import { fetchSyntheticModels, getFallbackModels } from "./models.js";
 // Re-export public API for tests and consumers
 export { parsePrice } from "./formatting.js";
 export { getFallbackModels } from "./models.js";
-export { buildProgressBar, fetchSyntheticQuota, formatTimeRemaining, getUsageColor } from "./quota.js";
+export {
+	buildProgressBar,
+	fetchSyntheticQuota,
+	formatTimeRemaining,
+	getQuotaSystemLabel,
+	getUsageColor,
+	hasVisibleQuotaBucket,
+	shouldDisplaySubscriptionQuota,
+} from "./quota.js";
 
 export default function (pi: ExtensionAPI) {
 	// Register provider synchronously with fallback models.
@@ -76,9 +84,9 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// After session starts, replace fallback models with live data from the API.
-	// We use ctx.modelRegistry.registerProvider() directly because pi.registerProvider()
-	// queues registrations that are only flushed during runner.initialize(), which has
-	// already completed by the time session_start fires.
+	// pi.registerProvider() now takes effect immediately after startup and also
+	// lets the runtime refresh the current model reference if the provider config
+	// changes beneath an already-selected model.
 	pi.on("session_start", async (_event, ctx) => {
 		const apiKey = await getSyntheticApiKey(ctx);
 		const hasKey = await hasSyntheticApiKey(ctx);
@@ -90,11 +98,11 @@ export default function (pi: ExtensionAPI) {
 			console.log(`  2. Add to ${AUTH_JSON_PATH} (see README for details)`);
 		}
 
-		// Fetch live models and register directly on the model registry
+		// Fetch live models and update the runtime provider registration
 		const models = await fetchSyntheticModels(apiKey);
 
 		if (models.length > 0) {
-			ctx.modelRegistry.registerProvider("synthetic", {
+			pi.registerProvider("synthetic", {
 				baseUrl: SYNTHETIC_API_BASE_URL,
 				apiKey: "SYNTHETIC_API_KEY",
 				api: "openai-completions",

--- a/packages/pi-synthetic-provider/extensions/quota.ts
+++ b/packages/pi-synthetic-provider/extensions/quota.ts
@@ -3,7 +3,7 @@
  */
 
 import { SYNTHETIC_QUOTAS_ENDPOINT } from "./config.js";
-import type { SyntheticQuotaResponse } from "./types.js";
+import type { QuotaBucket, SyntheticQuotaResponse } from "./types.js";
 
 /**
  * Fetch quota information from the Synthetic API.
@@ -66,4 +66,38 @@ export function getUsageColor(percent: number): "success" | "warning" | "error" 
 	if (percent < 60) return "success";
 	if (percent < 85) return "warning";
 	return "error";
+}
+
+/**
+ * Ignore empty zero-limit buckets that may appear when a quota feature is not enabled.
+ */
+export function hasVisibleQuotaBucket(bucket: QuotaBucket | undefined): bucket is QuotaBucket {
+	if (!bucket) return false;
+	return bucket.limit > 0 || bucket.requests > 0;
+}
+
+/**
+ * Describe which quota system shape the user is currently on.
+ */
+export function getQuotaSystemLabel(quota: SyntheticQuotaResponse): string {
+	const hasLegacyBuckets = [
+		quota.subscription,
+		quota.search?.hourly,
+		quota.toolCallDiscounts,
+		quota.freeToolCalls,
+	].some(hasVisibleQuotaBucket);
+	const hasEnhancedLimits = Boolean(quota.weeklyTokenLimit || quota.rollingFiveHourLimit);
+
+	if (hasLegacyBuckets && hasEnhancedLimits) return "Hybrid quota system";
+	if (hasEnhancedLimits) return "Enhanced quota system";
+	return "Classic quota system";
+}
+
+/**
+ * The legacy subscription bucket is not the primary limiter once the newer
+ * rolling/weekly quota system is present, so hide it for hybrid/enhanced users.
+ */
+export function shouldDisplaySubscriptionQuota(quota: SyntheticQuotaResponse): boolean {
+	const hasEnhancedLimits = Boolean(quota.weeklyTokenLimit || quota.rollingFiveHourLimit);
+	return !hasEnhancedLimits && hasVisibleQuotaBucket(quota.subscription);
 }

--- a/packages/pi-synthetic-provider/extensions/types.ts
+++ b/packages/pi-synthetic-provider/extensions/types.ts
@@ -32,6 +32,19 @@ export interface QuotaBucket {
 	renewsAt: string;
 }
 
+export interface WeeklyTokenLimit {
+	nextRegenAt: string;
+	percentRemaining: number;
+}
+
+export interface RollingFiveHourLimit {
+	nextTickAt: string;
+	tickPercent: number;
+	remaining: number;
+	max: number;
+	limited: boolean;
+}
+
 export interface SyntheticQuotaResponse {
 	subscription?: QuotaBucket;
 	search?: {
@@ -39,4 +52,6 @@ export interface SyntheticQuotaResponse {
 	};
 	freeToolCalls?: QuotaBucket;
 	toolCallDiscounts?: QuotaBucket;
+	weeklyTokenLimit?: WeeklyTokenLimit;
+	rollingFiveHourLimit?: RollingFiveHourLimit;
 }

--- a/packages/pi-synthetic-provider/package.json
+++ b/packages/pi-synthetic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-synthetic-provider",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Synthetic (synthetic.new) model provider for pi - Dynamic model fetching with reasoning, vision, and tools support",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

This updates `@benvargas/pi-synthetic-provider` for current pi runtime behavior and Synthetic's newer quota payloads.

## What changed

- bumped repo dev dependencies to `@mariozechner/pi-ai@^0.64.0` and `@mariozechner/pi-coding-agent@^0.64.0`
- updated the Synthetic provider live refresh path to use `pi.registerProvider(...)` during `session_start`
- expanded `/synthetic-quota` to handle classic, hybrid, and enhanced quota payloads
- added support for `rollingFiveHourLimit` and `weeklyTokenLimit`
- hid empty zero-limit quota buckets such as disabled `freeToolCalls`
- improved quota overlay dismissal so `Esc`, `Enter`, keypad `Enter`, and normalized terminal escape variants close reliably
- increased displayed quota percentage precision to two decimals
- documented `/synthetic-quota` and added compatibility notes
- bumped `@benvargas/pi-synthetic-provider` to `1.1.9`

## Why

Recent pi versions expect dynamic provider updates to go through `pi.registerProvider(...)`, and newer Synthetic accounts can return quota payloads that are not well represented by the legacy subscription-only view. This keeps model refresh and quota UI aligned with current runtime behavior.

## Testing

- `npm run check`
- `npm run test`

## Affected package

- `packages/pi-synthetic-provider`
