### PR TITLE
[codex] add GLM-5 fallback to synthetic provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5660,7 +5660,7 @@
     },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": "*"

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.10] - 2026-03-31
+
+### Added
+- Added `hf:zai-org/GLM-5` to fallback models so the provider exposes the new always-on model before the live catalog refresh completes and when the Synthetic API is unavailable.
+
+### Docs
+- Refreshed Synthetic provider docs/comments/tests to reflect GLM-5 availability and current fallback metadata.
+
 ## [1.1.9] - 2026-03-29
 
 ### Changed

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -72,13 +72,14 @@ pi --model synthetic
 
 ## Available Models
 
-Models are fetched dynamically. As of 2026-02-25, Synthetic provides:
+Models are fetched dynamically. As of 2026-03-31, Synthetic provides:
 
 | Model | ID | Reasoning | Vision | Context | Max Output |
 |-------|-----|-----------|--------|---------|------------|
 | **Kimi K2.5** | `hf:moonshotai/Kimi-K2.5` | Yes | Yes | 262K | 65K |
 | **MiniMax M2.1** | `hf:MiniMaxAI/MiniMax-M2.1` | Yes | No | 196K | 65K |
 | **MiniMax M2.5** | `hf:MiniMaxAI/MiniMax-M2.5` | Yes | Yes | 191K | 65K |
+| **GLM 5** | `hf:zai-org/GLM-5` | Yes | No | 192K | 65K |
 | **GLM 4.7** | `hf:zai-org/GLM-4.7` | Yes | No | 202K | 65K |
 
 Run `/synthetic-models` inside pi for the full, current catalog.

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -22,7 +22,8 @@ describe("pi-synthetic-provider helpers", () => {
 		expect(models.length).toBeGreaterThan(0);
 		expect(models.some((model) => model.id.includes("Kimi-K2.5"))).toBe(true);
 		expect(models.some((model) => model.id === "hf:MiniMaxAI/MiniMax-M2.5")).toBe(true);
-		for (const model of models.slice(0, 5)) {
+		expect(models.some((model) => model.id === "hf:zai-org/GLM-5")).toBe(true);
+		for (const model of models) {
 			expect(model.id).toEqual(expect.any(String));
 			expect(model.name).toEqual(expect.any(String));
 		}

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -37,11 +37,12 @@
  *   # Use default model
  *   pi --model synthetic
  *
- * Supported Models (as of 2026-02-25):
+ * Supported Models (as of 2026-03-31):
  * - hf:moonshotai/Kimi-K2.5 (reasoning + vision)
  * - hf:nvidia/Kimi-K2.5-NVFP4 (reasoning + vision, NVIDIA FP4 variant)
  * - hf:MiniMaxAI/MiniMax-M2.1 (reasoning)
  * - hf:MiniMaxAI/MiniMax-M2.5 (reasoning + vision)
+ * - hf:zai-org/GLM-5 (reasoning)
  * - hf:zai-org/GLM-4.7 (reasoning)
  *
  * Note: Models are fetched dynamically from the API at session start, so the

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -78,12 +78,13 @@ export async function fetchSyntheticModels(apiKey?: string): Promise<ProviderMod
 /**
  * Fallback models if API fetch fails.
  * Data sourced from: curl https://api.synthetic.new/openai/v1/models
- * Last updated: 2026-02-25
+ * Last updated: 2026-03-31
  *
  * Pricing format: $/million tokens
  * Synthetic-hosted models:
  * - Kimi-K2.5 & NVFP4: $0.55 input, $2.19 output, 262K context
  * - MiniMax-M2.5: $0.60 input, $3.00 output, 191K context
+ * - GLM-5: $1.00 input, $6.00 output, 192K context
  * - GLM-4.7: $0.55 input, $2.19 output, 202K context
  */
 export function getFallbackModels(): ProviderModelConfig[] {
@@ -145,6 +146,21 @@ export function getFallbackModels(): ProviderModelConfig[] {
 				cacheWrite: 0,
 			},
 			contextWindow: 191488,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:zai-org/GLM-5",
+			name: "zai-org/GLM-5",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1,
+				output: 6,
+				cacheRead: 1,
+				cacheWrite: 0,
+			},
+			contextWindow: 196608,
 			maxTokens: 65536,
 			compat: SYNTHETIC_COMPAT,
 		},

--- a/packages/pi-synthetic-provider/package.json
+++ b/packages/pi-synthetic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-synthetic-provider",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Synthetic (synthetic.new) model provider for pi - Dynamic model fetching with reasoning, vision, and tools support",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary
- add `hf:zai-org/GLM-5` to the Synthetic provider fallback model list
- update fallback tests and docs so startup/offline behavior matches the live catalog
- bump `@benvargas/pi-synthetic-provider` from `1.1.9` to `1.1.10`

## Why
Synthetic now serves `GLM-5` as an always-on model. Live catalog refresh already picked it up, but the extension's fallback registration path was still stale. That meant startup and offline behavior could lag behind the current Synthetic catalog.

## Impact
The Synthetic provider now exposes `GLM-5` earlier in session startup and still includes it when the Synthetic models API is unavailable.

## Validation
- `npm run test -- packages/pi-synthetic-provider`
- `npm run typecheck`
