### PR TITLE
feat: add minimal Anthropic OAuth Claude Code compatibility patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pi packages can include extensions, skills, prompt templates, and themes. See th
 | [@benvargas/pi-ancestor-discovery](./packages/pi-ancestor-discovery/) | Extension | Ancestor discovery for skills, prompts, themes |
 | [@benvargas/pi-cut-stack](./packages/pi-cut-stack/) | Extension | Cut-stack editor shortcuts |
 | [@benvargas/pi-openai-fast](./packages/pi-openai-fast/) | Extension | `/fast` toggle for OpenAI priority service tier on supported GPT-5.4 models |
+| [@benvargas/pi-claude-code-use](./packages/pi-claude-code-use/) | Extension | Patch Anthropic OAuth payloads for sub use |
 
 Each package has its own README with setup instructions, usage, and configuration details.
 
@@ -55,6 +56,7 @@ pi install npm:@benvargas/pi-firecrawl
 pi install npm:@benvargas/pi-ancestor-discovery
 pi install npm:@benvargas/pi-cut-stack
 pi install npm:@benvargas/pi-openai-fast
+pi install npm:@benvargas/pi-claude-code-use
 ```
 
 </details>
@@ -84,6 +86,7 @@ pi remove npm:@benvargas/pi-firecrawl
 pi remove npm:@benvargas/pi-ancestor-discovery
 pi remove npm:@benvargas/pi-cut-stack
 pi remove npm:@benvargas/pi-openai-fast
+pi remove npm:@benvargas/pi-claude-code-use
 ```
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5630,7 +5630,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/jiti": "^2.6.5"
+        "@mariozechner/jiti": "^2.6.5",
+        "@mariozechner/pi-ai": "*",
+        "@sinclair/typebox": "*"
       },
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.57.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,6 +915,10 @@
       "resolved": "packages/pi-antigravity-image-gen",
       "link": true
     },
+    "node_modules/@benvargas/pi-claude-code-use": {
+      "resolved": "packages/pi-claude-code-use",
+      "link": true
+    },
     "node_modules/@benvargas/pi-cut-stack": {
       "resolved": "packages/pi-cut-stack",
       "link": true
@@ -5619,6 +5623,17 @@
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
         "@sinclair/typebox": "*"
+      }
+    },
+    "packages/pi-claude-code-use": {
+      "name": "@benvargas/pi-claude-code-use",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.5"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": ">=0.57.0"
       }
     },
     "packages/pi-cut-stack": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "./packages/pi-firecrawl/extensions/index.ts",
       "./packages/pi-ancestor-discovery/extensions/index.ts",
       "./packages/pi-cut-stack/extensions/index.ts",
-      "./packages/pi-openai-fast/extensions/index.ts"
+      "./packages/pi-openai-fast/extensions/index.ts",
+      "./packages/pi-claude-code-use/extensions/index.ts"
     ]
   },
   "devDependencies": {

--- a/packages/pi-claude-code-use/LICENSE
+++ b/packages/pi-claude-code-use/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ben Vargas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -1,0 +1,84 @@
+# @benvargas/pi-claude-code-use
+
+`pi-claude-code-use` keeps Pi's built-in `anthropic` provider intact and applies the smallest payload changes that were needed for Anthropic OAuth subscription use in Pi.
+
+This package targets the Anthropic subscription OAuth path for the built-in `anthropic` provider.
+
+## What It Changes
+
+When Pi is using Anthropic OAuth, this extension:
+
+- rewrites only the minimum known system prompt text needed for classification: `pi itself` -> `the cli itself`
+- preserves Pi's original `system[]` structure and cache metadata instead of rebuilding the Anthropic request shape
+- auto-aliases the known companion tools in this monorepo to MCP-style names for Anthropic OAuth
+- filters unknown non-MCP extension tools by default for Anthropic OAuth requests
+- leaves Pi core in charge of Anthropic OAuth transport, headers, model definitions, and streaming
+
+It does not register a new provider or replace Pi's Anthropic request transport.
+
+## Install
+
+```bash
+pi install npm:@benvargas/pi-claude-code-use
+```
+
+Or try it without installing:
+
+```bash
+pi -e .
+```
+
+## Usage
+
+Install the package and continue using the normal `anthropic` provider with Anthropic OAuth login:
+
+```bash
+/login anthropic
+/model anthropic/claude-opus-4-6
+```
+
+No extra configuration is required.
+
+Optional environment variables:
+
+- `PI_CLAUDE_CODE_USE_DEBUG_LOG=/tmp/pi-claude-code-use.log` writes the final rewritten Anthropic request payload for debugging.
+- `PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER=1` disables the default non-core tool filtering. This is mainly for debugging; the filtered mode is what avoided Anthropic's extra-usage classification in the normal Pi environment.
+
+## Companion Tool Aliases
+
+When these companion extensions are loaded, `pi-claude-code-use` registers Anthropic-safe MCP aliases for them:
+
+- `web_search_exa` -> `mcp__exa__web_search`
+- `get_code_context_exa` -> `mcp__exa__get_code_context`
+- `firecrawl_scrape` -> `mcp__firecrawl__scrape`
+- `firecrawl_map` -> `mcp__firecrawl__map`
+- `firecrawl_search` -> `mcp__firecrawl__search`
+- `generate_image` -> `mcp__antigravity__generate_image`
+- `image_quota` -> `mcp__antigravity__image_quota`
+
+This lets the model see Claude-Code-like MCP tool names while the local Pi session still executes the real tool implementations from the companion extensions.
+
+## Guidance For Extension Authors
+
+Anthropic's OAuth subscription path appears to fingerprint tool names. Flat extension tool names such as `web_search_exa` were rejected in live testing, while MCP-style names such as `mcp__exa__web_search` were accepted.
+
+If you want a custom tool to survive Anthropic OAuth filtering cleanly, prefer registering it directly under an MCP-style name:
+
+```text
+mcp__<server>__<tool>
+```
+
+Examples:
+
+- `mcp__exa__web_search`
+- `mcp__firecrawl__scrape`
+- `mcp__mytools__lookup_customer`
+
+If an extension keeps a flat legacy name for non-Anthropic use, it can also register an MCP-style alias alongside it. `pi-claude-code-use` already does this centrally for the known companion tools in this repo, but unknown non-MCP tool names will still be filtered out on Anthropic OAuth requests.
+
+## Notes
+
+- The extension applies to Anthropic OAuth requests in general, rather than a fixed model allowlist.
+- Non-OAuth Anthropic usage is left unchanged.
+- In practice, unknown non-MCP extension tools were the remaining trigger for Anthropic extra-usage classification, so this package keeps core tools, keeps MCP-style tools, auto-aliases the known companion tools above, and filters the rest.
+- Pi `v0.66.0` may still show its built-in OAuth subscription warning banner even when the request path works. That banner is UI logic in Pi, not a signal that the upstream request is still being billed as extra usage.

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import piClaudeCodeUse, { _test } from "../extensions/index.js";
@@ -60,6 +63,8 @@ function createMockPi(): MockPi {
 
 describe("pi-claude-code-use", () => {
 	beforeEach(() => {
+		_test.autoActivatedAliasNames.clear();
+		_test.setLastAutoManagedToolNames(undefined);
 		_test.registeredAliasNames.clear();
 	});
 
@@ -231,6 +236,98 @@ describe("pi-claude-code-use", () => {
 		expect(transformed.tools?.map((tool) => tool.name)).toEqual(["mcp__exa__web_search"]);
 	});
 
+	it("rewrites legacy tool_use names in prior assistant messages when the alias is advertised", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Searching..." },
+						{ type: "tool_use", id: "toolu_123", name: "web_search_exa", input: { q: "pi" } },
+					],
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "toolu_123", content: "done" }],
+				},
+			],
+			tools: [
+				{ name: "web_search_exa", description: "Original", input_schema: { type: "object", properties: {} } },
+				{
+					name: "mcp__exa__web_search",
+					description: "Alias",
+					input_schema: { type: "object", properties: {} },
+				},
+			],
+		});
+
+		expect(transformed.messages).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Searching..." },
+					{ type: "tool_use", id: "toolu_123", name: "mcp__exa__web_search", input: { q: "pi" } },
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "toolu_123", content: "done" }],
+			},
+		]);
+	});
+
+	it("preserves prior tool_use names when no advertised MCP alias exists", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "toolu_123", name: "web_search_exa", input: { q: "pi" } }],
+				},
+			],
+			tools: [{ name: "web_search_exa", description: "Original", input_schema: { type: "object", properties: {} } }],
+		});
+
+		expect(transformed.messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_123", name: "web_search_exa", input: { q: "pi" } }],
+			},
+		]);
+	});
+
+	it("keeps alias remapping and deduplication active when tool filtering is disabled", () => {
+		const transformed = _test.transformAnthropicOAuthPayload(
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "tool_use", id: "toolu_123", name: "web_search_exa", input: { q: "pi" } }],
+					},
+				],
+				tool_choice: { type: "tool", name: "web_search_exa" },
+				tools: [
+					{ name: "web_search_exa", description: "Original", input_schema: { type: "object", properties: {} } },
+					{
+						name: "mcp__exa__web_search",
+						description: "Alias",
+						input_schema: { type: "object", properties: {} },
+					},
+					{ name: "totally_unknown_tool", description: "Unknown", input_schema: { type: "object", properties: {} } },
+				],
+			},
+			{ disableToolFiltering: true },
+		);
+
+		expect(transformed.tools?.map((tool) => tool.name)).toEqual(["mcp__exa__web_search", "totally_unknown_tool"]);
+		expect(transformed.tool_choice).toEqual({ type: "tool", name: "mcp__exa__web_search" });
+		expect(transformed.messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_123", name: "mcp__exa__web_search", input: { q: "pi" } }],
+			},
+		]);
+	});
+
 	it("adds extension-registered MCP aliases and removes only those aliases when disabling", () => {
 		const mockPi = createMockPi();
 		mockPi.getAllTools.mockReturnValue([
@@ -265,6 +362,8 @@ describe("pi-claude-code-use", () => {
 	it("prunes stale extension-registered aliases when enabling aliases", () => {
 		const mockPi = createMockPi();
 		_test.registeredAliasNames.add("mcp__exa__web_search");
+		_test.autoActivatedAliasNames.add("mcp__exa__web_search");
+		_test.setLastAutoManagedToolNames(["read", "mcp__exa__web_search"]);
 		mockPi.getAllTools.mockReturnValue([
 			{ name: "web_search_exa", sourceInfo: {} },
 			{ name: "mcp__exa__web_search", sourceInfo: {} },
@@ -274,6 +373,19 @@ describe("pi-claude-code-use", () => {
 		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, true);
 
 		expect(mockPi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("preserves extension-registered aliases users enabled directly", () => {
+		const mockPi = createMockPi();
+		_test.registeredAliasNames.add("mcp__exa__web_search");
+		_test.autoActivatedAliasNames.add("mcp__exa__web_search");
+		_test.setLastAutoManagedToolNames(["read", "web_search_exa", "mcp__exa__web_search"]);
+		mockPi.getAllTools.mockReturnValue([{ name: "mcp__exa__web_search", sourceInfo: {} }]);
+		mockPi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, true);
+
+		expect(mockPi.setActiveTools).not.toHaveBeenCalled();
 	});
 
 	it("capture shim preserves companion flag access after flag registration", () => {
@@ -296,5 +408,126 @@ describe("pi-claude-code-use", () => {
 		capturePi.registerFlag("--exa-mcp-tools", { description: "tools", type: "string" });
 		expect(mockPi.registerFlag).toHaveBeenCalledWith("--exa-mcp-tools", { description: "tools", type: "string" });
 		expect(capturePi.getFlag("--exa-mcp-tools")).toBe("web_search_exa");
+	});
+
+	it("recognizes companion package sources from package root and extensions dir layouts", () => {
+		expect(
+			_test.matchesCompanionExtensionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						baseDir: "/tmp/node_modules/@benvargas/pi-exa-mcp",
+						path: "/tmp/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+					},
+				} as never,
+				{
+					baseDirName: "pi-exa-mcp",
+					packageName: "@benvargas/pi-exa-mcp",
+					toolAliases: [],
+				},
+			),
+		).toBe(true);
+
+		expect(
+			_test.matchesCompanionExtensionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						baseDir: "/tmp/worktree/packages/pi-exa-mcp/extensions",
+						path: "/tmp/worktree/packages/pi-exa-mcp/extensions/index.ts",
+					},
+				} as never,
+				{
+					baseDirName: "pi-exa-mcp",
+					packageName: "@benvargas/pi-exa-mcp",
+					toolAliases: [],
+				},
+			),
+		).toBe(true);
+	});
+
+	it("does not treat unrelated tools with matching names as companion aliases", () => {
+		expect(
+			_test.matchesCompanionExtensionSource(
+				{
+					name: "generate_image",
+					sourceInfo: {
+						baseDir: "/tmp/node_modules/some-other-extension",
+						path: "/tmp/node_modules/some-other-extension/extensions/index.ts",
+					},
+				} as never,
+				{
+					baseDirName: "pi-antigravity-image-gen",
+					packageName: "@benvargas/pi-antigravity-image-gen",
+					toolAliases: [],
+				},
+			),
+		).toBe(false);
+	});
+
+	it("registers alias tools from companion package-root layouts", async () => {
+		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		const tempRoot = join(tempParent, "pi-exa-mcp");
+		try {
+			const extensionsDir = join(tempRoot, "extensions");
+			mkdirSync(extensionsDir, { recursive: true });
+			writeFileSync(
+				join(extensionsDir, "index.js"),
+				[
+					'import { StringEnum } from "@mariozechner/pi-ai";',
+					'import { DEFAULT_MAX_BYTES } from "@mariozechner/pi-coding-agent";',
+					'import { Type } from "@sinclair/typebox";',
+					"const schema = Type.Object({ q: StringEnum(['web']) });",
+					"export default function companion(pi) {",
+					"  pi.registerTool({",
+					'    name: "web_search_exa",',
+					"    description: 'Search web ' + String(DEFAULT_MAX_BYTES),",
+					"    inputSchema: schema,",
+					"    async execute() { return { content: [{ type: 'text', text: String(DEFAULT_MAX_BYTES) }] }; }",
+					"  });",
+					"}",
+					"",
+				].join("\n"),
+				"utf8",
+			);
+
+			const mockPi = createMockPi();
+			mockPi.getAllTools.mockReturnValue([
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						baseDir: tempRoot,
+						path: join(tempRoot, "extensions", "index.js"),
+					},
+				},
+			]);
+
+			await _test.registerKnownMonorepoToolAliases(mockPi as unknown as ExtensionAPI);
+
+			expect(mockPi.registerTool).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: "mcp__exa__web_search",
+				}),
+			);
+		} finally {
+			rmSync(tempParent, { recursive: true, force: true });
+		}
+	});
+
+	it("does not alias unrelated matching tool names in non-eager registration", async () => {
+		const mockPi = createMockPi();
+		mockPi.getAllTools.mockReturnValue([
+			{
+				name: "generate_image",
+				sourceInfo: {
+					baseDir: "/tmp/node_modules/some-other-extension",
+					path: "/tmp/node_modules/some-other-extension/extensions/index.ts",
+				},
+			},
+		]);
+
+		await _test.registerKnownMonorepoToolAliases(mockPi as unknown as ExtensionAPI);
+
+		expect(mockPi.registerTool).not.toHaveBeenCalled();
 	});
 });

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -1,0 +1,300 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import piClaudeCodeUse, { _test } from "../extensions/index.js";
+
+type MockPi = {
+	events: ExtensionAPI["events"];
+	exec: ReturnType<typeof vi.fn>;
+	getActiveTools: ReturnType<typeof vi.fn>;
+	getAllTools: ReturnType<typeof vi.fn>;
+	getCommands: ReturnType<typeof vi.fn>;
+	getFlag: ReturnType<typeof vi.fn>;
+	getSessionName: ReturnType<typeof vi.fn>;
+	getThinkingLevel: ReturnType<typeof vi.fn>;
+	on: ReturnType<typeof vi.fn>;
+	setActiveTools: ReturnType<typeof vi.fn>;
+	setLabel: ReturnType<typeof vi.fn>;
+	setModel: ReturnType<typeof vi.fn>;
+	setSessionName: ReturnType<typeof vi.fn>;
+	setThinkingLevel: ReturnType<typeof vi.fn>;
+	appendEntry: ReturnType<typeof vi.fn>;
+	registerCommand: ReturnType<typeof vi.fn>;
+	registerFlag: ReturnType<typeof vi.fn>;
+	registerMessageRenderer: ReturnType<typeof vi.fn>;
+	registerTool: ReturnType<typeof vi.fn>;
+	registerProvider: ReturnType<typeof vi.fn>;
+	registerShortcut: ReturnType<typeof vi.fn>;
+	sendMessage: ReturnType<typeof vi.fn>;
+	sendUserMessage: ReturnType<typeof vi.fn>;
+	unregisterProvider: ReturnType<typeof vi.fn>;
+};
+
+function createMockPi(): MockPi {
+	return {
+		appendEntry: vi.fn(),
+		events: {} as ExtensionAPI["events"],
+		exec: vi.fn(),
+		getActiveTools: vi.fn(() => []),
+		getAllTools: vi.fn(() => []),
+		getCommands: vi.fn(() => []),
+		getFlag: vi.fn(() => undefined),
+		getSessionName: vi.fn(() => undefined),
+		getThinkingLevel: vi.fn(() => "medium"),
+		on: vi.fn(),
+		registerCommand: vi.fn(),
+		registerFlag: vi.fn(),
+		registerMessageRenderer: vi.fn(),
+		registerTool: vi.fn(),
+		registerProvider: vi.fn(),
+		registerShortcut: vi.fn(),
+		sendMessage: vi.fn(),
+		sendUserMessage: vi.fn(),
+		setActiveTools: vi.fn(),
+		setLabel: vi.fn(),
+		setModel: vi.fn(async () => true),
+		setSessionName: vi.fn(),
+		setThinkingLevel: vi.fn(),
+		unregisterProvider: vi.fn(),
+	};
+}
+
+describe("pi-claude-code-use", () => {
+	beforeEach(() => {
+		_test.registeredAliasNames.clear();
+	});
+
+	it("registers only extension hooks and does not override the anthropic provider", async () => {
+		const mockPi = createMockPi();
+		await piClaudeCodeUse(mockPi as unknown as ExtensionAPI);
+
+		expect(mockPi.on).toHaveBeenCalledWith("session_start", expect.any(Function));
+		expect(mockPi.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
+		expect(mockPi.on).toHaveBeenCalledWith("before_provider_request", expect.any(Function));
+		expect(mockPi.registerProvider).not.toHaveBeenCalled();
+	});
+
+	it("does not call runtime-only tool APIs during extension load", async () => {
+		const mockPi = createMockPi();
+		mockPi.getAllTools.mockImplementation(() => {
+			throw new Error("runtime not initialized");
+		});
+		mockPi.getActiveTools.mockImplementation(() => {
+			throw new Error("runtime not initialized");
+		});
+
+		await expect(piClaudeCodeUse(mockPi as unknown as ExtensionAPI)).resolves.toBeUndefined();
+	});
+
+	it("does not eagerly register companion aliases when the source tools are not loaded", async () => {
+		const mockPi = createMockPi();
+		mockPi.getAllTools.mockReturnValue([{ name: "read", sourceInfo: {} }]);
+
+		await piClaudeCodeUse(mockPi as unknown as ExtensionAPI);
+
+		expect(mockPi.registerTool).not.toHaveBeenCalled();
+	});
+
+	it("rewrites only the minimum Anthropic OAuth system prompt text and tool list", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			model: "claude-opus-4-6",
+			system: [
+				{
+					type: "text",
+					text: "You are Claude Code, Anthropic's official CLI for Claude.",
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+				{
+					type: "text",
+					text: "Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):",
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+			],
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "Fix the bug." }],
+				},
+			],
+			tools: [
+				{ name: "Read", description: "Read files", input_schema: { type: "object", properties: {} } },
+				{ type: "web_search", name: "web_search", search_context_size: "high" },
+				{ name: "web_search_exa", description: "Search web", input_schema: { type: "object", properties: {} } },
+				{
+					name: "mcp__exa__web_search",
+					description: "Search web alias",
+					input_schema: { type: "object", properties: {} },
+				},
+				{
+					name: "mcp__custom__lookup",
+					description: "Already MCP-shaped",
+					input_schema: { type: "object", properties: {} },
+				},
+				{ name: "totally_unknown_tool", description: "Unknown", input_schema: { type: "object", properties: {} } },
+			],
+		});
+
+		expect(transformed.system).toEqual([
+			{
+				type: "text",
+				text: "You are Claude Code, Anthropic's official CLI for Claude.",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+			{
+				type: "text",
+				text: "Pi documentation (read only when the user asks about the cli itself, its SDK, extensions, themes, skills, or TUI):",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+		]);
+		expect(transformed.tools?.map((tool) => tool.name ?? tool.type)).toEqual([
+			"Read",
+			"web_search",
+			"mcp__exa__web_search",
+			"mcp__custom__lookup",
+		]);
+		expect("metadata" in transformed).toBe(false);
+	});
+
+	it("preserves non-text system blocks while rewriting text system blocks", () => {
+		const nonTextBlock = { type: "guard_content", guard: "keep-me" };
+		const transformed = _test.transformAnthropicOAuthPayload({
+			system: [
+				{
+					type: "text",
+					text: "Pi documentation (read only when the user asks about pi itself):",
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+				nonTextBlock,
+			],
+			messages: [{ role: "user", content: "hello" }],
+		});
+
+		expect(transformed.system).toEqual([
+			{
+				type: "text",
+				text: "Pi documentation (read only when the user asks about the cli itself):",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+			nonTextBlock,
+		]);
+	});
+
+	it("preserves string-form system prompts while rewriting text content", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			system: "Pi documentation (read only when the user asks about pi itself):",
+			messages: [{ role: "user", content: "hello" }],
+		});
+
+		expect(transformed.system).toBe("Pi documentation (read only when the user asks about the cli itself):");
+	});
+
+	it("maps known monorepo tools to MCP aliases and preserves existing MCP names", () => {
+		const advertisedToolNames = new Set([
+			"mcp__exa__web_search",
+			"mcp__exa__get_code_context",
+			"mcp__firecrawl__scrape",
+		]);
+
+		expect(_test.getClaudeCodeVisibleToolName("web_search_exa", advertisedToolNames)).toBe("mcp__exa__web_search");
+		expect(_test.getClaudeCodeVisibleToolName("get_code_context_exa", advertisedToolNames)).toBe(
+			"mcp__exa__get_code_context",
+		);
+		expect(_test.getClaudeCodeVisibleToolName("firecrawl_scrape", advertisedToolNames)).toBe("mcp__firecrawl__scrape");
+		expect(_test.getClaudeCodeVisibleToolName("mcp__custom__lookup", advertisedToolNames)).toBe("mcp__custom__lookup");
+		expect(_test.getClaudeCodeVisibleToolName("Read", advertisedToolNames)).toBe("Read");
+		expect(_test.getClaudeCodeVisibleToolName("totally_unknown_tool", advertisedToolNames)).toBeUndefined();
+	});
+
+	it("filters known companion tools when the MCP alias is not advertised", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			system: [{ type: "text", text: "Pi documentation (read only when the user asks about pi itself):" }],
+			messages: [{ role: "user", content: "Search now." }],
+			tools: [{ name: "web_search_exa", description: "Original", input_schema: { type: "object", properties: {} } }],
+		});
+
+		expect(transformed.tools).toEqual([]);
+	});
+
+	it("deduplicates tool names after alias remapping", () => {
+		const transformed = _test.transformAnthropicOAuthPayload({
+			system: [{ type: "text", text: "Pi documentation (read only when the user asks about pi itself):" }],
+			messages: [{ role: "user", content: "Search now." }],
+			tools: [
+				{ name: "web_search_exa", description: "Original", input_schema: { type: "object", properties: {} } },
+				{
+					name: "mcp__exa__web_search",
+					description: "Alias",
+					input_schema: { type: "object", properties: {} },
+				},
+			],
+		});
+
+		expect(transformed.tools?.map((tool) => tool.name)).toEqual(["mcp__exa__web_search"]);
+	});
+
+	it("adds extension-registered MCP aliases and removes only those aliases when disabling", () => {
+		const mockPi = createMockPi();
+		mockPi.getAllTools.mockReturnValue([
+			{ name: "web_search_exa", sourceInfo: {} },
+			{ name: "mcp__exa__web_search", sourceInfo: {} },
+		]);
+		mockPi.getActiveTools.mockReturnValue(["read", "web_search_exa"]);
+
+		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, true);
+
+		expect(mockPi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		mockPi.setActiveTools.mockClear();
+		_test.registeredAliasNames.add("mcp__exa__web_search");
+		mockPi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, false);
+
+		expect(mockPi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa"]);
+	});
+
+	it("preserves user-provided MCP tools when disabling aliases", () => {
+		const mockPi = createMockPi();
+		mockPi.getAllTools.mockReturnValue([{ name: "mcp__exa__web_search", sourceInfo: {} }]);
+		mockPi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, false);
+
+		expect(mockPi.setActiveTools).not.toHaveBeenCalled();
+	});
+
+	it("prunes stale extension-registered aliases when enabling aliases", () => {
+		const mockPi = createMockPi();
+		_test.registeredAliasNames.add("mcp__exa__web_search");
+		mockPi.getAllTools.mockReturnValue([
+			{ name: "web_search_exa", sourceInfo: {} },
+			{ name: "mcp__exa__web_search", sourceInfo: {} },
+		]);
+		mockPi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncKnownAliasToolActivation(mockPi as unknown as ExtensionAPI, true);
+
+		expect(mockPi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("capture shim preserves companion flag access after flag registration", () => {
+		const mockPi = createMockPi();
+		const registeredFlags = new Set<string>();
+		mockPi.registerFlag.mockImplementation((name: string) => {
+			registeredFlags.add(name);
+		});
+		mockPi.getFlag.mockImplementation((name: string) => {
+			if (!registeredFlags.has(name)) {
+				return undefined;
+			}
+			return name === "--exa-mcp-tools" ? "web_search_exa" : undefined;
+		});
+
+		const capturedTools = new Map();
+		const capturePi = _test.createCapturePi(mockPi as unknown as ExtensionAPI, capturedTools);
+
+		expect(capturePi.getFlag("--exa-mcp-tools")).toBeUndefined();
+		capturePi.registerFlag("--exa-mcp-tools", { description: "tools", type: "string" });
+		expect(mockPi.registerFlag).toHaveBeenCalledWith("--exa-mcp-tools", { description: "tools", type: "string" });
+		expect(capturePi.getFlag("--exa-mcp-tools")).toBe("web_search_exa");
+	});
+});

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -1,0 +1,500 @@
+import { appendFileSync } from "node:fs";
+import { createJiti } from "@mariozechner/jiti";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type CacheControl = {
+	type: "ephemeral";
+	ttl?: "1h";
+};
+
+type TextBlock = {
+	type: "text";
+	text: string;
+	cache_control?: CacheControl;
+	[key: string]: unknown;
+};
+
+type AnthropicPayload = {
+	tool_choice?: {
+		type?: string;
+		name?: string;
+		[key: string]: unknown;
+	};
+	tools?: Array<{
+		type?: string;
+		name?: string;
+		[key: string]: unknown;
+	}>;
+	system?: string | unknown[];
+	[key: string]: unknown;
+};
+
+type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
+type RegisteredToolDefinition = Parameters<ExtensionAPI["registerTool"]>[0];
+type ExtensionFactory = (pi: ExtensionAPI) => void | Promise<void>;
+type KnownCompanionExtension = {
+	baseDirName: string;
+	toolAliases: Array<readonly [originalName: string, aliasName: string]>;
+};
+
+const debugLogPath = process.env.PI_CLAUDE_CODE_USE_DEBUG_LOG;
+const disableToolFiltering = process.env.PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER === "1";
+
+// Mirror Pi core's Anthropic Claude Code tool set from:
+// packages/ai/src/providers/anthropic.ts -> claudeCodeTools
+const ALLOWED_TOOL_NAMES = new Set(
+	[
+		"read",
+		"write",
+		"edit",
+		"bash",
+		"grep",
+		"glob",
+		"askuserquestion",
+		"enterplanmode",
+		"exitplanmode",
+		"killshell",
+		"notebookedit",
+		"skill",
+		"task",
+		"taskoutput",
+		"todowrite",
+		"webfetch",
+		"websearch",
+	].map((name) => name.toLowerCase()),
+);
+
+const KNOWN_MONOREPO_TOOL_ALIASES = new Map<string, string>([
+	["web_search_exa", "mcp__exa__web_search"],
+	["get_code_context_exa", "mcp__exa__get_code_context"],
+	["firecrawl_scrape", "mcp__firecrawl__scrape"],
+	["firecrawl_map", "mcp__firecrawl__map"],
+	["firecrawl_search", "mcp__firecrawl__search"],
+	["generate_image", "mcp__antigravity__generate_image"],
+	["image_quota", "mcp__antigravity__image_quota"],
+]);
+
+const KNOWN_COMPANION_EXTENSIONS: KnownCompanionExtension[] = [
+	{
+		baseDirName: "pi-exa-mcp",
+		toolAliases: [
+			["web_search_exa", "mcp__exa__web_search"],
+			["get_code_context_exa", "mcp__exa__get_code_context"],
+		],
+	},
+	{
+		baseDirName: "pi-firecrawl",
+		toolAliases: [
+			["firecrawl_scrape", "mcp__firecrawl__scrape"],
+			["firecrawl_map", "mcp__firecrawl__map"],
+			["firecrawl_search", "mcp__firecrawl__search"],
+		],
+	},
+	{
+		baseDirName: "pi-antigravity-image-gen",
+		toolAliases: [
+			["generate_image", "mcp__antigravity__generate_image"],
+			["image_quota", "mcp__antigravity__image_quota"],
+		],
+	},
+];
+
+const capturedToolDefinitionsByExtensionDir = new Map<string, Promise<Map<string, RegisteredToolDefinition>>>();
+const registeredAliasNames = new Set<string>();
+let extensionImportLoader:
+	| {
+			import(path: string, options?: { default?: boolean }): Promise<unknown>;
+	  }
+	| undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTextBlock(value: unknown): value is TextBlock {
+	return isRecord(value) && value.type === "text" && typeof value.text === "string";
+}
+
+function normalizeToolName(name: string | undefined): string {
+	return (name ?? "").trim().toLowerCase();
+}
+
+function isCoreClaudeCodeToolName(name: string | undefined): boolean {
+	return ALLOWED_TOOL_NAMES.has(normalizeToolName(name));
+}
+
+function isMcpToolName(name: string | undefined): boolean {
+	return normalizeToolName(name).startsWith("mcp__");
+}
+
+function getKnownAliasName(toolName: string | undefined): string | undefined {
+	return KNOWN_MONOREPO_TOOL_ALIASES.get(normalizeToolName(toolName));
+}
+
+function getAdvertisedToolNames(tools: AnthropicPayload["tools"]): Set<string> {
+	if (!Array.isArray(tools)) {
+		return new Set<string>();
+	}
+	return new Set(
+		tools
+			.map((tool) => (typeof tool?.name === "string" ? normalizeToolName(tool.name) : ""))
+			.filter((name) => name.length > 0),
+	);
+}
+
+function clonePayload(payload: AnthropicPayload): AnthropicPayload {
+	return JSON.parse(JSON.stringify(payload)) as AnthropicPayload;
+}
+
+function rewritePiSelfReferences(text: string): string {
+	return text.replaceAll("pi itself", "the cli itself");
+}
+
+function rewriteSystemBlocks(system: AnthropicPayload["system"]): AnthropicPayload["system"] {
+	if (typeof system === "string") {
+		return rewritePiSelfReferences(system);
+	}
+	if (!Array.isArray(system)) {
+		return system;
+	}
+	return system.map((block) => {
+		if (!isTextBlock(block)) {
+			return block;
+		}
+		return {
+			...block,
+			text: rewritePiSelfReferences(block.text),
+		};
+	});
+}
+
+function getClaudeCodeVisibleToolName(
+	toolName: string | undefined,
+	advertisedToolNames?: Set<string>,
+): string | undefined {
+	if (!toolName) {
+		return undefined;
+	}
+	if (isCoreClaudeCodeToolName(toolName) || isMcpToolName(toolName)) {
+		return toolName;
+	}
+	const aliasName = getKnownAliasName(toolName);
+	if (!aliasName) {
+		return undefined;
+	}
+	if (advertisedToolNames && !advertisedToolNames.has(normalizeToolName(aliasName))) {
+		return undefined;
+	}
+	return aliasName;
+}
+
+function filterToolsForClaudeCode(payload: AnthropicPayload): AnthropicPayload {
+	if (disableToolFiltering || !Array.isArray(payload.tools)) {
+		return payload;
+	}
+
+	const advertisedToolNames = getAdvertisedToolNames(payload.tools);
+	const seenToolNames = new Set<string>();
+	const tools = payload.tools.flatMap((tool) => {
+		if (typeof tool?.type === "string" && tool.type.trim().length > 0) {
+			return [tool];
+		}
+
+		const visibleName = getClaudeCodeVisibleToolName(
+			typeof tool?.name === "string" ? tool.name : undefined,
+			advertisedToolNames,
+		);
+		const normalizedVisibleName = normalizeToolName(visibleName);
+		if (!visibleName || seenToolNames.has(normalizedVisibleName)) {
+			return [];
+		}
+
+		seenToolNames.add(normalizedVisibleName);
+		return [{ ...tool, name: visibleName }];
+	});
+
+	let toolChoice = payload.tool_choice;
+	if (toolChoice?.type === "tool" && typeof toolChoice.name === "string") {
+		const visibleToolName = getClaudeCodeVisibleToolName(toolChoice.name, advertisedToolNames);
+		toolChoice = visibleToolName ? { ...toolChoice, name: visibleToolName } : undefined;
+	}
+
+	return {
+		...payload,
+		tools,
+		...(toolChoice ? { tool_choice: toolChoice } : {}),
+		...(toolChoice ? {} : { tool_choice: undefined }),
+	};
+}
+
+function transformAnthropicOAuthPayload(payload: AnthropicPayload): AnthropicPayload {
+	const nextPayload = filterToolsForClaudeCode(clonePayload(payload));
+	if (nextPayload.system !== undefined) {
+		nextPayload.system = rewriteSystemBlocks(nextPayload.system);
+	}
+	return nextPayload;
+}
+
+function debugLogPayload(payload: unknown): void {
+	if (!debugLogPath) {
+		return;
+	}
+
+	try {
+		appendFileSync(debugLogPath, `${new Date().toISOString()}\n${JSON.stringify(payload, null, 2)}\n---\n`, "utf8");
+	} catch {}
+}
+
+async function importExtensionFactoryFromDir(baseDir: string): Promise<ExtensionFactory | undefined> {
+	const candidates = [`${baseDir.replace(/\/$/, "")}/index.ts`, `${baseDir.replace(/\/$/, "")}/index.js`];
+
+	if (!extensionImportLoader) {
+		extensionImportLoader = createJiti(import.meta.url, {
+			moduleCache: false,
+			alias: {
+				"@mariozechner/pi-coding-agent": import.meta.resolve("@mariozechner/pi-coding-agent"),
+				"@mariozechner/pi-ai": import.meta.resolve("@mariozechner/pi-ai"),
+				"@mariozechner/pi-ai/oauth": import.meta.resolve("@mariozechner/pi-ai/oauth"),
+				"@sinclair/typebox": import.meta.resolve("@sinclair/typebox"),
+			},
+		});
+	}
+
+	for (const candidate of candidates) {
+		try {
+			const module = (await extensionImportLoader.import(candidate, { default: true })) as { default?: unknown };
+			return typeof module.default === "function" ? (module.default as ExtensionFactory) : undefined;
+		} catch {}
+	}
+
+	return undefined;
+}
+
+function createCapturePi(realPi: ExtensionAPI, capturedTools: Map<string, RegisteredToolDefinition>): ExtensionAPI {
+	const registeredFlags = new Set<string>();
+	return {
+		on() {},
+		registerTool(tool) {
+			capturedTools.set(tool.name, tool as unknown as RegisteredToolDefinition);
+		},
+		registerCommand() {},
+		registerShortcut() {},
+		registerFlag(name, options) {
+			registeredFlags.add(name);
+			realPi.registerFlag(name, options);
+		},
+		getFlag(name) {
+			if (!registeredFlags.has(name)) {
+				return undefined;
+			}
+			return realPi.getFlag(name);
+		},
+		registerMessageRenderer() {},
+		sendMessage() {},
+		sendUserMessage() {},
+		appendEntry() {},
+		setSessionName() {},
+		getSessionName() {
+			return undefined;
+		},
+		setLabel() {},
+		exec(command, args, options) {
+			return realPi.exec(command, args, options);
+		},
+		getActiveTools() {
+			return realPi.getActiveTools();
+		},
+		getAllTools() {
+			return realPi.getAllTools();
+		},
+		setActiveTools(toolNames) {
+			realPi.setActiveTools(toolNames);
+		},
+		getCommands() {
+			return realPi.getCommands();
+		},
+		setModel(model) {
+			return realPi.setModel(model);
+		},
+		getThinkingLevel() {
+			return realPi.getThinkingLevel();
+		},
+		setThinkingLevel(level) {
+			realPi.setThinkingLevel(level);
+		},
+		registerProvider() {},
+		unregisterProvider() {},
+		events: realPi.events,
+	} as ExtensionAPI;
+}
+
+async function captureToolDefinitionsFromDir(
+	baseDir: string,
+	realPi: ExtensionAPI,
+): Promise<Map<string, RegisteredToolDefinition>> {
+	let capturedPromise = capturedToolDefinitionsByExtensionDir.get(baseDir);
+	if (!capturedPromise) {
+		capturedPromise = (async () => {
+			const factory = await importExtensionFactoryFromDir(baseDir);
+			if (!factory) {
+				return new Map<string, RegisteredToolDefinition>();
+			}
+
+			const capturedTools = new Map<string, RegisteredToolDefinition>();
+			await factory(createCapturePi(realPi, capturedTools));
+			return capturedTools;
+		})();
+		capturedToolDefinitionsByExtensionDir.set(baseDir, capturedPromise);
+	}
+
+	return capturedPromise;
+}
+
+function cloneAliasedToolDefinition(tool: RegisteredToolDefinition, aliasName: string): RegisteredToolDefinition {
+	return {
+		...tool,
+		name: aliasName,
+		label: tool.label?.startsWith("MCP ") ? tool.label : `MCP ${tool.label ?? aliasName}`,
+	};
+}
+
+async function registerKnownMonorepoToolAliases(pi: ExtensionAPI): Promise<void> {
+	const toolsByName = new Map<string, ToolInfo>();
+	for (const tool of pi.getAllTools()) {
+		toolsByName.set(tool.name, tool);
+	}
+
+	const aliasJobs = Array.from(KNOWN_MONOREPO_TOOL_ALIASES.entries()).map(async ([originalName, aliasName]) => {
+		if (registeredAliasNames.has(aliasName) || toolsByName.has(aliasName)) {
+			return;
+		}
+
+		const originalTool = toolsByName.get(originalName);
+		const baseDir = originalTool?.sourceInfo?.baseDir;
+		if (!originalTool || !baseDir) {
+			return;
+		}
+
+		const capturedTools = await captureToolDefinitionsFromDir(baseDir, pi);
+		const definition = capturedTools.get(originalName);
+		if (!definition) {
+			return;
+		}
+
+		pi.registerTool(cloneAliasedToolDefinition(definition, aliasName));
+		registeredAliasNames.add(aliasName);
+	});
+
+	await Promise.all(aliasJobs);
+}
+
+async function eagerRegisterKnownCompanionAliases(pi: ExtensionAPI): Promise<void> {
+	const toolsByName = new Map<string, ToolInfo>();
+	const availableToolNames = new Set<string>();
+	for (const tool of pi.getAllTools()) {
+		const normalizedToolName = normalizeToolName(tool.name);
+		toolsByName.set(normalizedToolName, tool);
+		availableToolNames.add(normalizedToolName);
+	}
+
+	for (const companionExtension of KNOWN_COMPANION_EXTENSIONS) {
+		const pendingAliases = companionExtension.toolAliases.filter(([originalName, aliasName]) => {
+			const normalizedAliasName = normalizeToolName(aliasName);
+			const originalTool = toolsByName.get(originalName);
+			if (!originalTool?.sourceInfo?.baseDir) {
+				return false;
+			}
+			return !registeredAliasNames.has(aliasName) && !availableToolNames.has(normalizedAliasName);
+		});
+
+		if (pendingAliases.length === 0) {
+			continue;
+		}
+
+		for (const [originalName, aliasName] of pendingAliases) {
+			const originalTool = toolsByName.get(originalName);
+			const baseDir = originalTool?.sourceInfo?.baseDir;
+			if (!baseDir) {
+				continue;
+			}
+
+			const capturedTools = await captureToolDefinitionsFromDir(baseDir, pi);
+			const definition = capturedTools.get(originalName);
+			if (!definition) {
+				continue;
+			}
+			pi.registerTool(cloneAliasedToolDefinition(definition, aliasName));
+			registeredAliasNames.add(aliasName);
+			availableToolNames.add(normalizeToolName(aliasName));
+		}
+	}
+}
+
+function syncKnownAliasToolActivation(pi: ExtensionAPI, enableAliases: boolean): void {
+	const activeToolNames = pi.getActiveTools();
+	const allToolNames = new Set(pi.getAllTools().map((tool) => tool.name));
+	const activeOriginalToolNames = new Set(activeToolNames.map(normalizeToolName));
+	const aliasesForActiveTools = Array.from(KNOWN_MONOREPO_TOOL_ALIASES.entries())
+		.filter(([originalName, aliasName]) => activeOriginalToolNames.has(originalName) && allToolNames.has(aliasName))
+		.map(([, aliasName]) => aliasName);
+	const nextToolNames = enableAliases
+		? Array.from(
+				new Set([
+					...activeToolNames.filter((toolName) => !registeredAliasNames.has(toolName)),
+					...aliasesForActiveTools,
+				]),
+			)
+		: activeToolNames.filter((toolName) => !registeredAliasNames.has(toolName));
+
+	if (
+		nextToolNames.length !== activeToolNames.length ||
+		nextToolNames.some((toolName, index) => toolName !== activeToolNames[index])
+	) {
+		pi.setActiveTools(nextToolNames);
+	}
+}
+
+export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
+	pi.on("session_start", async () => {
+		await eagerRegisterKnownCompanionAliases(pi);
+		await registerKnownMonorepoToolAliases(pi);
+	});
+
+	pi.on("before_agent_start", async (_event, ctx) => {
+		await eagerRegisterKnownCompanionAliases(pi);
+		await registerKnownMonorepoToolAliases(pi);
+		const model = ctx.model;
+		const enableAliases =
+			model?.provider === "anthropic" && model !== undefined && ctx.modelRegistry.isUsingOAuth(model);
+		syncKnownAliasToolActivation(pi, enableAliases);
+	});
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const model = ctx.model;
+		if (!model || model.provider !== "anthropic" || !ctx.modelRegistry.isUsingOAuth(model)) {
+			return undefined;
+		}
+		if (!isRecord(event.payload)) {
+			return undefined;
+		}
+
+		const transformedPayload = transformAnthropicOAuthPayload(event.payload as AnthropicPayload);
+		debugLogPayload(transformedPayload);
+		return transformedPayload;
+	});
+}
+
+export const _test = {
+	createCapturePi,
+	filterToolsForClaudeCode,
+	getClaudeCodeVisibleToolName,
+	getAdvertisedToolNames,
+	getKnownAliasName,
+	isCoreClaudeCodeToolName,
+	isMcpToolName,
+	registerKnownMonorepoToolAliases,
+	registeredAliasNames,
+	rewritePiSelfReferences,
+	syncKnownAliasToolActivation,
+	transformAnthropicOAuthPayload,
+};

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -1,6 +1,10 @@
 import { appendFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
 import { createJiti } from "@mariozechner/jiti";
+import * as bundledPiAi from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import * as bundledPiCodingAgent from "@mariozechner/pi-coding-agent";
+import * as bundledTypebox from "@sinclair/typebox";
 
 type CacheControl = {
 	type: "ephemeral";
@@ -15,6 +19,11 @@ type TextBlock = {
 };
 
 type AnthropicPayload = {
+	messages?: Array<{
+		role?: string;
+		content?: string | unknown[];
+		[key: string]: unknown;
+	}>;
 	tool_choice?: {
 		type?: string;
 		name?: string;
@@ -29,16 +38,20 @@ type AnthropicPayload = {
 	[key: string]: unknown;
 };
 
+type AnthropicTransformOptions = {
+	disableToolFiltering?: boolean;
+};
+
 type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
 type RegisteredToolDefinition = Parameters<ExtensionAPI["registerTool"]>[0];
 type ExtensionFactory = (pi: ExtensionAPI) => void | Promise<void>;
 type KnownCompanionExtension = {
 	baseDirName: string;
+	packageName: string;
 	toolAliases: Array<readonly [originalName: string, aliasName: string]>;
 };
 
 const debugLogPath = process.env.PI_CLAUDE_CODE_USE_DEBUG_LOG;
-const disableToolFiltering = process.env.PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER === "1";
 
 // Mirror Pi core's Anthropic Claude Code tool set from:
 // packages/ai/src/providers/anthropic.ts -> claudeCodeTools
@@ -77,6 +90,7 @@ const KNOWN_MONOREPO_TOOL_ALIASES = new Map<string, string>([
 const KNOWN_COMPANION_EXTENSIONS: KnownCompanionExtension[] = [
 	{
 		baseDirName: "pi-exa-mcp",
+		packageName: "@benvargas/pi-exa-mcp",
 		toolAliases: [
 			["web_search_exa", "mcp__exa__web_search"],
 			["get_code_context_exa", "mcp__exa__get_code_context"],
@@ -84,6 +98,7 @@ const KNOWN_COMPANION_EXTENSIONS: KnownCompanionExtension[] = [
 	},
 	{
 		baseDirName: "pi-firecrawl",
+		packageName: "@benvargas/pi-firecrawl",
 		toolAliases: [
 			["firecrawl_scrape", "mcp__firecrawl__scrape"],
 			["firecrawl_map", "mcp__firecrawl__map"],
@@ -92,6 +107,7 @@ const KNOWN_COMPANION_EXTENSIONS: KnownCompanionExtension[] = [
 	},
 	{
 		baseDirName: "pi-antigravity-image-gen",
+		packageName: "@benvargas/pi-antigravity-image-gen",
 		toolAliases: [
 			["generate_image", "mcp__antigravity__generate_image"],
 			["image_quota", "mcp__antigravity__image_quota"],
@@ -99,13 +115,25 @@ const KNOWN_COMPANION_EXTENSIONS: KnownCompanionExtension[] = [
 	},
 ];
 
+const KNOWN_COMPANION_EXTENSION_BY_TOOL_NAME = new Map<string, KnownCompanionExtension>(
+	KNOWN_COMPANION_EXTENSIONS.flatMap((companionExtension) =>
+		companionExtension.toolAliases.map(([originalName]) => [originalName, companionExtension] as const),
+	),
+);
+
 const capturedToolDefinitionsByExtensionDir = new Map<string, Promise<Map<string, RegisteredToolDefinition>>>();
 const registeredAliasNames = new Set<string>();
+const autoActivatedAliasNames = new Set<string>();
+let lastAutoManagedToolNames: string[] | undefined;
 let extensionImportLoader:
 	| {
 			import(path: string, options?: { default?: boolean }): Promise<unknown>;
 	  }
 	| undefined;
+
+function isToolFilteringDisabled(options?: AnthropicTransformOptions): boolean {
+	return options?.disableToolFiltering ?? process.env.PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER === "1";
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -140,6 +168,57 @@ function getAdvertisedToolNames(tools: AnthropicPayload["tools"]): Set<string> {
 			.map((tool) => (typeof tool?.name === "string" ? normalizeToolName(tool.name) : ""))
 			.filter((name) => name.length > 0),
 	);
+}
+
+function rewriteAnthropicToolChoice(
+	toolChoice: AnthropicPayload["tool_choice"],
+	advertisedToolNames: Set<string>,
+	disableFiltering: boolean,
+): AnthropicPayload["tool_choice"] {
+	if (toolChoice?.type !== "tool" || typeof toolChoice.name !== "string") {
+		return toolChoice;
+	}
+
+	const visibleToolName = getClaudeCodeVisibleToolName(toolChoice.name, advertisedToolNames);
+	if (visibleToolName) {
+		return visibleToolName === toolChoice.name ? toolChoice : { ...toolChoice, name: visibleToolName };
+	}
+	if (disableFiltering) {
+		return toolChoice;
+	}
+	return undefined;
+}
+
+function rewriteHistoricalToolUseBlocks(
+	messages: AnthropicPayload["messages"],
+	advertisedToolNames: Set<string>,
+): AnthropicPayload["messages"] {
+	if (!Array.isArray(messages)) {
+		return messages;
+	}
+
+	return messages.map((message) => {
+		if (!Array.isArray(message?.content)) {
+			return message;
+		}
+
+		let changed = false;
+		const content = message.content.map((block) => {
+			if (!isRecord(block) || block.type !== "tool_use" || typeof block.name !== "string") {
+				return block;
+			}
+
+			const visibleToolName = getClaudeCodeVisibleToolName(block.name, advertisedToolNames);
+			if (!visibleToolName || visibleToolName === block.name) {
+				return block;
+			}
+
+			changed = true;
+			return { ...block, name: visibleToolName };
+		});
+
+		return changed ? { ...message, content } : message;
+	});
 }
 
 function clonePayload(payload: AnthropicPayload): AnthropicPayload {
@@ -188,49 +267,58 @@ function getClaudeCodeVisibleToolName(
 	return aliasName;
 }
 
-function filterToolsForClaudeCode(payload: AnthropicPayload): AnthropicPayload {
-	if (disableToolFiltering || !Array.isArray(payload.tools)) {
-		return payload;
-	}
-
+function filterToolsForClaudeCode(payload: AnthropicPayload, options?: AnthropicTransformOptions): AnthropicPayload {
+	const disableFiltering = isToolFilteringDisabled(options);
 	const advertisedToolNames = getAdvertisedToolNames(payload.tools);
-	const seenToolNames = new Set<string>();
-	const tools = payload.tools.flatMap((tool) => {
-		if (typeof tool?.type === "string" && tool.type.trim().length > 0) {
-			return [tool];
-		}
+	let tools = payload.tools;
 
-		const visibleName = getClaudeCodeVisibleToolName(
-			typeof tool?.name === "string" ? tool.name : undefined,
-			advertisedToolNames,
-		);
-		const normalizedVisibleName = normalizeToolName(visibleName);
-		if (!visibleName || seenToolNames.has(normalizedVisibleName)) {
-			return [];
-		}
+	if (Array.isArray(payload.tools)) {
+		const seenToolNames = new Set<string>();
+		tools = payload.tools.flatMap((tool) => {
+			if (typeof tool?.type === "string" && tool.type.trim().length > 0) {
+				return [tool];
+			}
 
-		seenToolNames.add(normalizedVisibleName);
-		return [{ ...tool, name: visibleName }];
-	});
+			const originalName = typeof tool?.name === "string" ? tool.name : undefined;
+			const visibleName = getClaudeCodeVisibleToolName(originalName, advertisedToolNames);
+			const nextName = visibleName ?? (disableFiltering ? originalName : undefined);
+			const normalizedNextName = normalizeToolName(nextName);
+			if (!nextName || seenToolNames.has(normalizedNextName)) {
+				return [];
+			}
 
-	let toolChoice = payload.tool_choice;
-	if (toolChoice?.type === "tool" && typeof toolChoice.name === "string") {
-		const visibleToolName = getClaudeCodeVisibleToolName(toolChoice.name, advertisedToolNames);
-		toolChoice = visibleToolName ? { ...toolChoice, name: visibleToolName } : undefined;
+			seenToolNames.add(normalizedNextName);
+			return [nextName === originalName ? tool : { ...tool, name: nextName }];
+		});
 	}
+
+	const rewrittenToolChoice = rewriteAnthropicToolChoice(
+		payload.tool_choice,
+		getAdvertisedToolNames(tools),
+		disableFiltering,
+	);
 
 	return {
 		...payload,
-		tools,
-		...(toolChoice ? { tool_choice: toolChoice } : {}),
-		...(toolChoice ? {} : { tool_choice: undefined }),
+		...(tools ? { tools } : {}),
+		...(rewrittenToolChoice ? { tool_choice: rewrittenToolChoice } : {}),
+		...(rewrittenToolChoice ? {} : { tool_choice: undefined }),
 	};
 }
 
-function transformAnthropicOAuthPayload(payload: AnthropicPayload): AnthropicPayload {
-	const nextPayload = filterToolsForClaudeCode(clonePayload(payload));
+function transformAnthropicOAuthPayload(
+	payload: AnthropicPayload,
+	options?: AnthropicTransformOptions,
+): AnthropicPayload {
+	const nextPayload = filterToolsForClaudeCode(clonePayload(payload), options);
 	if (nextPayload.system !== undefined) {
 		nextPayload.system = rewriteSystemBlocks(nextPayload.system);
+	}
+	if (nextPayload.messages !== undefined) {
+		nextPayload.messages = rewriteHistoricalToolUseBlocks(
+			nextPayload.messages,
+			getAdvertisedToolNames(nextPayload.tools),
+		);
 	}
 	return nextPayload;
 }
@@ -246,28 +334,56 @@ function debugLogPayload(payload: unknown): void {
 }
 
 async function importExtensionFactoryFromDir(baseDir: string): Promise<ExtensionFactory | undefined> {
-	const candidates = [`${baseDir.replace(/\/$/, "")}/index.ts`, `${baseDir.replace(/\/$/, "")}/index.js`];
+	const normalizedBaseDir = baseDir.replace(/\/$/, "");
+	const candidates = [
+		`${normalizedBaseDir}/index.ts`,
+		`${normalizedBaseDir}/index.js`,
+		`${normalizedBaseDir}/extensions/index.ts`,
+		`${normalizedBaseDir}/extensions/index.js`,
+	];
 
 	if (!extensionImportLoader) {
 		extensionImportLoader = createJiti(import.meta.url, {
 			moduleCache: false,
-			alias: {
-				"@mariozechner/pi-coding-agent": import.meta.resolve("@mariozechner/pi-coding-agent"),
-				"@mariozechner/pi-ai": import.meta.resolve("@mariozechner/pi-ai"),
-				"@mariozechner/pi-ai/oauth": import.meta.resolve("@mariozechner/pi-ai/oauth"),
-				"@sinclair/typebox": import.meta.resolve("@sinclair/typebox"),
+			tryNative: false,
+			virtualModules: {
+				"@mariozechner/pi-ai": bundledPiAi,
+				"@mariozechner/pi-coding-agent": bundledPiCodingAgent,
+				"@sinclair/typebox": bundledTypebox,
 			},
 		});
 	}
 
 	for (const candidate of candidates) {
 		try {
-			const module = (await extensionImportLoader.import(candidate, { default: true })) as { default?: unknown };
-			return typeof module.default === "function" ? (module.default as ExtensionFactory) : undefined;
+			const factory = await extensionImportLoader.import(candidate, { default: true });
+			return typeof factory === "function" ? (factory as ExtensionFactory) : undefined;
 		} catch {}
 	}
 
 	return undefined;
+}
+
+function matchesCompanionExtensionSource(
+	tool: ToolInfo | undefined,
+	companionExtension: KnownCompanionExtension,
+): boolean {
+	const baseDir = tool?.sourceInfo?.baseDir;
+	if (!baseDir) {
+		return false;
+	}
+
+	const baseName = basename(baseDir);
+	if (baseName === companionExtension.baseDirName) {
+		return true;
+	}
+
+	if (baseName === "extensions" && basename(dirname(baseDir)) === companionExtension.baseDirName) {
+		return true;
+	}
+
+	const packagePath = tool?.sourceInfo?.path;
+	return typeof packagePath === "string" && packagePath.includes(companionExtension.packageName);
 }
 
 function createCapturePi(realPi: ExtensionAPI, capturedTools: Map<string, RegisteredToolDefinition>): ExtensionAPI {
@@ -370,8 +486,14 @@ async function registerKnownMonorepoToolAliases(pi: ExtensionAPI): Promise<void>
 		}
 
 		const originalTool = toolsByName.get(originalName);
+		const companionExtension = KNOWN_COMPANION_EXTENSION_BY_TOOL_NAME.get(originalName);
 		const baseDir = originalTool?.sourceInfo?.baseDir;
-		if (!originalTool || !baseDir) {
+		if (
+			!originalTool ||
+			!baseDir ||
+			!companionExtension ||
+			!matchesCompanionExtensionSource(originalTool, companionExtension)
+		) {
 			return;
 		}
 
@@ -401,7 +523,7 @@ async function eagerRegisterKnownCompanionAliases(pi: ExtensionAPI): Promise<voi
 		const pendingAliases = companionExtension.toolAliases.filter(([originalName, aliasName]) => {
 			const normalizedAliasName = normalizeToolName(aliasName);
 			const originalTool = toolsByName.get(originalName);
-			if (!originalTool?.sourceInfo?.baseDir) {
+			if (!matchesCompanionExtensionSource(originalTool, companionExtension)) {
 				return false;
 			}
 			return !registeredAliasNames.has(aliasName) && !availableToolNames.has(normalizedAliasName);
@@ -434,6 +556,16 @@ function syncKnownAliasToolActivation(pi: ExtensionAPI, enableAliases: boolean):
 	const activeToolNames = pi.getActiveTools();
 	const allToolNames = new Set(pi.getAllTools().map((tool) => tool.name));
 	const activeOriginalToolNames = new Set(activeToolNames.map(normalizeToolName));
+	const selectionMatchesLastAutoManagedState =
+		lastAutoManagedToolNames !== undefined &&
+		lastAutoManagedToolNames.length === activeToolNames.length &&
+		lastAutoManagedToolNames.every((toolName, index) => toolName === activeToolNames[index]);
+	const activeAliasToolNames = activeToolNames.filter(
+		(toolName) => registeredAliasNames.has(toolName) && allToolNames.has(toolName),
+	);
+	const preservedUserAliasToolNames = activeAliasToolNames.filter(
+		(toolName) => !autoActivatedAliasNames.has(toolName) || !selectionMatchesLastAutoManagedState,
+	);
 	const aliasesForActiveTools = Array.from(KNOWN_MONOREPO_TOOL_ALIASES.entries())
 		.filter(([originalName, aliasName]) => activeOriginalToolNames.has(originalName) && allToolNames.has(aliasName))
 		.map(([, aliasName]) => aliasName);
@@ -441,16 +573,29 @@ function syncKnownAliasToolActivation(pi: ExtensionAPI, enableAliases: boolean):
 		? Array.from(
 				new Set([
 					...activeToolNames.filter((toolName) => !registeredAliasNames.has(toolName)),
+					...preservedUserAliasToolNames,
 					...aliasesForActiveTools,
 				]),
 			)
 		: activeToolNames.filter((toolName) => !registeredAliasNames.has(toolName));
+
+	autoActivatedAliasNames.clear();
+	if (enableAliases) {
+		for (const aliasName of aliasesForActiveTools) {
+			if (!preservedUserAliasToolNames.includes(aliasName)) {
+				autoActivatedAliasNames.add(aliasName);
+			}
+		}
+	}
 
 	if (
 		nextToolNames.length !== activeToolNames.length ||
 		nextToolNames.some((toolName, index) => toolName !== activeToolNames[index])
 	) {
 		pi.setActiveTools(nextToolNames);
+		lastAutoManagedToolNames = [...nextToolNames];
+	} else if (!enableAliases) {
+		lastAutoManagedToolNames = undefined;
 	}
 }
 
@@ -492,7 +637,15 @@ export const _test = {
 	getKnownAliasName,
 	isCoreClaudeCodeToolName,
 	isMcpToolName,
+	matchesCompanionExtensionSource,
 	registerKnownMonorepoToolAliases,
+	autoActivatedAliasNames,
+	getLastAutoManagedToolNames() {
+		return lastAutoManagedToolNames;
+	},
+	setLastAutoManagedToolNames(value: string[] | undefined) {
+		lastAutoManagedToolNames = value;
+	},
 	registeredAliasNames,
 	rewritePiSelfReferences,
 	syncKnownAliasToolActivation,

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@benvargas/pi-claude-code-use",
+  "version": "1.0.0",
+  "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
+  "keywords": [
+    "pi",
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "anthropic",
+    "claude",
+    "claude-code",
+    "oauth",
+    "subscription"
+  ],
+  "type": "module",
+  "files": [
+    "extensions/",
+    "README.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions/index.ts"
+    ]
+  },
+  "dependencies": {
+    "@mariozechner/jiti": "^2.6.5"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.57.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ben-vargas/pi-packages.git",
+    "directory": "packages/pi-claude-code-use"
+  },
+  "author": "Ben Vargas",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ben-vargas/pi-packages/issues"
+  },
+  "homepage": "https://github.com/ben-vargas/pi-packages/tree/main/packages/pi-claude-code-use#readme"
+}

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -25,7 +25,9 @@
     ]
   },
   "dependencies": {
-    "@mariozechner/jiti": "^2.6.5"
+    "@mariozechner/jiti": "^2.6.5",
+    "@mariozechner/pi-ai": "*",
+    "@sinclair/typebox": "*"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": ">=0.57.0"


### PR DESCRIPTION
## Summary

Adds a new package, `@benvargas/pi-claude-code-use`, that patches Pi's built-in `anthropic` provider for Anthropic OAuth subscription use while keeping Pi core's Anthropic transport intact.

This is the minimal version of the fix. It does not replace Pi's Anthropic request path or inject a custom client. Instead, it:

- rewrites only the minimum known system prompt text needed for classification
- preserves Pi's original `system[]` layout and cache metadata
- adds MCP-style aliases for known companion tools in this monorepo
- filters unknown non-MCP extension tools for Anthropic OAuth requests

## Motivation

Anthropic OAuth subscription tokens in Pi can be classified as third-party usage and billed against extra usage rather than Claude subscription use.

Through live testing, the minimum working change set in Pi was:

- rewrite `pi itself` -> `the cli itself` in the Anthropic OAuth system prompt
- expose known extension tools under MCP-style names such as `mcp__exa__web_search`
- filter unknown non-MCP extension tools that still trigger extra-usage classification

This package keeps Pi core behavior wherever possible and only patches the request payload and tool surface.

## What Changed

### New package

Added:

- `packages/pi-claude-code-use/extensions/index.ts`
- `packages/pi-claude-code-use/__tests__/index.test.ts`
- `packages/pi-claude-code-use/README.md`
- `packages/pi-claude-code-use/package.json`
- `packages/pi-claude-code-use/LICENSE`

### Root wiring

Updated:

- `package.json`
- `README.md`

## Behavior

When Pi is using Anthropic OAuth, the extension now:

- preserves Pi core's Anthropic OAuth transport and headers
- rewrites only:
  - `pi itself` -> `the cli itself`
- auto-registers MCP aliases for known companion tools:
  - `web_search_exa` -> `mcp__exa__web_search`
  - `get_code_context_exa` -> `mcp__exa__get_code_context`
  - `firecrawl_scrape` -> `mcp__firecrawl__scrape`
  - `firecrawl_map` -> `mcp__firecrawl__map`
  - `firecrawl_search` -> `mcp__firecrawl__search`
  - `generate_image` -> `mcp__antigravity__generate_image`
  - `image_quota` -> `mcp__antigravity__image_quota`
- filters unknown non-MCP extension tools from the Anthropic OAuth payload

Non-OAuth Anthropic usage is unchanged.

## Why this approach

A heavier branch was also explored that emulates more of Claude Code's transport fingerprinting. This PR intentionally uses the smaller version first because it:

- is much smaller and easier to maintain
- keeps Pi core Anthropic behavior in place
- preserves prompt caching layout better by leaving `system[]` intact
- was sufficient in live testing for Anthropic OAuth plus MCP-style companion tools

## Testing

Ran:

- `npm run check`
- `npx vitest run packages/pi-claude-code-use/__tests__/index.test.ts`

Live verification:

- Anthropic OAuth print-mode request succeeded with:
  - `anthropic/claude-opus-4-6`
- Anthropic OAuth tool use succeeded with:
  - `mcp__exa__web_search`

## Notes / Limitations

- This is based on observed Anthropic OAuth classification behavior, not an official public contract.
- Unknown non-MCP extension tools are still filtered out for Anthropic OAuth.
- The package includes guidance for extension authors to register tools directly as:
  - `mcp__<server>__<tool>`
- Pi may still show its built-in Anthropic OAuth warning banner. That UI warning is separate from whether the upstream request is actually accepted as subscription use.
