### PR TITLE
feat(pi-claude-code-use): Anthropic OAuth compatibility extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -915,6 +915,10 @@
       "resolved": "packages/pi-antigravity-image-gen",
       "link": true
     },
+    "node_modules/@benvargas/pi-claude-code-use": {
+      "resolved": "packages/pi-claude-code-use",
+      "link": true
+    },
     "node_modules/@benvargas/pi-cut-stack": {
       "resolved": "packages/pi-cut-stack",
       "link": true
@@ -5619,6 +5623,19 @@
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
         "@sinclair/typebox": "*"
+      }
+    },
+    "packages/pi-claude-code-use": {
+      "name": "@benvargas/pi-claude-code-use",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.5",
+        "@mariozechner/pi-ai": "*",
+        "@sinclair/typebox": "*"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": ">=0.57.0"
       }
     },
     "packages/pi-cut-stack": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "./packages/pi-firecrawl/extensions/index.ts",
       "./packages/pi-ancestor-discovery/extensions/index.ts",
       "./packages/pi-cut-stack/extensions/index.ts",
-      "./packages/pi-openai-fast/extensions/index.ts"
+      "./packages/pi-openai-fast/extensions/index.ts",
+      "./packages/pi-claude-code-use/extensions/index.ts"
     ]
   },
   "devDependencies": {

--- a/packages/pi-claude-code-use/LICENSE
+++ b/packages/pi-claude-code-use/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ben Vargas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -1,0 +1,111 @@
+# @benvargas/pi-claude-code-use
+
+`pi-claude-code-use` keeps Pi's built-in `anthropic` provider intact and applies the smallest payload changes needed for Anthropic OAuth subscription use in Pi.
+
+It does not register a new provider or replace Pi's Anthropic request transport. Pi core remains in charge of OAuth transport, headers, model definitions, and streaming.
+
+## What It Changes
+
+When Pi is using Anthropic OAuth, this extension intercepts outbound API requests via the `before_provider_request` hook and:
+
+- **System prompt rewrite** -- replaces `pi itself` with `the cli itself` in system prompt text. Preserves Pi's original `system[]` structure, `cache_control` metadata, and non-text blocks.
+- **Tool filtering** -- passes through core Claude Code tools, Anthropic-native typed tools (e.g. `web_search`), and any tool prefixed with `mcp__`. Unknown flat-named tools are filtered out.
+- **Companion tool remapping** -- renames known companion extension tools from their flat names to MCP-style aliases (e.g. `web_search_exa` becomes `mcp__exa__web_search`). Duplicate flat entries are removed after remapping.
+- **tool_choice remapping** -- if `tool_choice` references a flat companion name that was remapped, the reference is updated to the MCP alias. If it references a tool that was filtered out, `tool_choice` is removed from the payload.
+- **Message history rewriting** -- `tool_use` blocks in conversation history that reference flat companion names are rewritten to their MCP aliases so the model sees consistent tool names across the conversation.
+- **Companion alias registration** -- at session start and before each agent turn, discovers loaded companion extensions, captures their tool definitions via a jiti-based shim, and registers MCP-alias copies so the model can invoke them under Claude Code-compatible names.
+- **Alias activation tracking** -- auto-activates MCP aliases when their flat counterpart is active under Anthropic OAuth. Tracks provenance (auto-managed vs user-selected) so that disabling OAuth only removes auto-activated aliases, preserving any the user explicitly enabled.
+
+Non-OAuth Anthropic usage and non-Anthropic providers are left completely unchanged.
+
+## Install
+
+```bash
+pi install npm:@benvargas/pi-claude-code-use
+```
+
+Or load it directly without installing:
+
+```bash
+pi -e /path/to/pi-packages/packages/pi-claude-code-use/extensions/index.ts
+```
+
+## Usage
+
+Install the package and continue using the normal `anthropic` provider with Anthropic OAuth login:
+
+```bash
+/login anthropic
+/model anthropic/claude-opus-4-6
+```
+
+No extra configuration is required.
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `PI_CLAUDE_CODE_USE_DEBUG_LOG` | Set to a file path to enable debug logging. Writes two JSON entries per Anthropic OAuth request: one with `"stage": "before"` (the original payload from Pi) and one with `"stage": "after"` (the transformed payload sent to Anthropic). |
+| `PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER` | Set to `1` to disable tool filtering. System prompt rewriting still applies, but all tools pass through unchanged. Useful for debugging whether a tool-filtering issue is causing a problem. |
+
+Example:
+
+```bash
+PI_CLAUDE_CODE_USE_DEBUG_LOG=/tmp/pi-claude-debug.log pi -e /path/to/extensions/index.ts --model anthropic/claude-sonnet-4-20250514
+```
+
+## Companion Tool Aliases
+
+When these companion extensions from this monorepo are loaded alongside `pi-claude-code-use`, MCP aliases are automatically registered and remapped:
+
+| Flat name | MCP alias |
+|---|---|
+| `web_search_exa` | `mcp__exa__web_search` |
+| `get_code_context_exa` | `mcp__exa__get_code_context` |
+| `firecrawl_scrape` | `mcp__firecrawl__scrape` |
+| `firecrawl_map` | `mcp__firecrawl__map` |
+| `firecrawl_search` | `mcp__firecrawl__search` |
+| `generate_image` | `mcp__antigravity__generate_image` |
+| `image_quota` | `mcp__antigravity__image_quota` |
+
+### How companion discovery works
+
+The extension identifies companion tools by matching `sourceInfo` metadata that Pi attaches to each registered tool:
+
+1. **baseDir match** -- if the tool's `sourceInfo.baseDir` directory name matches the companion's directory name (e.g. `pi-exa-mcp`).
+2. **Path match** -- if the tool's `sourceInfo.path` contains the companion's scoped package name (e.g. `@benvargas/pi-exa-mcp`) or directory name as a path segment. This handles npm installs, git clones, and monorepo layouts where `baseDir` points to the repo root rather than the individual package.
+
+Once a companion tool is identified, its extension factory is loaded via jiti into a capture shim to obtain the full tool definition, which is then re-registered under the MCP alias name.
+
+## Core Tools Allowlist
+
+The following tool names always pass through filtering (case-insensitive). This list mirrors Pi core's `claudeCodeTools` in `packages/ai/src/providers/anthropic.ts`:
+
+`Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode`, `KillShell`, `NotebookEdit`, `Skill`, `Task`, `TaskOutput`, `TodoWrite`, `WebFetch`, `WebSearch`
+
+Additionally, any tool with a `type` field (Anthropic-native tools like `web_search`) and any tool prefixed with `mcp__` always passes through.
+
+## Guidance For Extension Authors
+
+Anthropic's OAuth subscription path appears to fingerprint tool names. Flat extension tool names such as `web_search_exa` were rejected in live testing, while MCP-style names such as `mcp__exa__web_search` were accepted.
+
+If you want a custom tool to survive Anthropic OAuth filtering cleanly, prefer registering it directly under an MCP-style name:
+
+```text
+mcp__<server>__<tool>
+```
+
+Examples:
+
+- `mcp__exa__web_search`
+- `mcp__firecrawl__scrape`
+- `mcp__mytools__lookup_customer`
+
+If an extension keeps a flat legacy name for non-Anthropic use, it can also register an MCP-style alias alongside it. `pi-claude-code-use` already does this centrally for the known companion tools in this repo, but unknown non-MCP tool names will still be filtered out on Anthropic OAuth requests.
+
+## Notes
+
+- The extension activates for all Anthropic OAuth requests regardless of model, rather than using a fixed model allowlist.
+- Non-OAuth Anthropic usage (API key auth) is left unchanged.
+- In practice, unknown non-MCP extension tools were the remaining trigger for Anthropic's extra-usage classification, so this package keeps core tools, keeps MCP-style tools, auto-aliases the known companion tools above, and filters the rest.
+- Pi may show its built-in OAuth subscription warning banner even when the request path works correctly. That banner is UI logic in Pi, not a signal that the upstream request is being billed as extra usage.

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -578,6 +578,7 @@ describe("pi-claude-code-use", () => {
 
 	it("activates MCP aliases for active companion tools, then removes them on disable", () => {
 		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
 		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
 		pi.getActiveTools.mockReturnValue(["read", "web_search_exa"]);
 
@@ -586,7 +587,6 @@ describe("pi-claude-code-use", () => {
 
 		// Now disable: should remove the alias
 		pi.setActiveTools.mockClear();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
 		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
@@ -677,31 +677,44 @@ describe("pi-claude-code-use", () => {
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
 	});
 
+	it("does not auto-manage MCP aliases that were not registered by this extension", () => {
+		const pi = createMockPi();
+		// mcp__exa__web_search exists in allTools and activeTools, but is NOT in registeredMcpAliases
+		// (simulates a third-party extension providing this MCP tool directly)
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		// Enable aliases: should NOT add mcp__exa__web_search to desiredAliases since it's not in registeredMcpAliases
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+
+		// Disable aliases: the third-party alias must remain untouched
+		pi.setActiveTools.mockClear();
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+
+		// mcp__exa__web_search was never auto-activated by us, so it must NOT be removed
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+	});
+
 	// ----------------------------------------------------------------
 	// Capture shim
 	// ----------------------------------------------------------------
 
-	it("forwards flag registration and gates flag access through the capture shim", () => {
-		const registeredFlags = new Set<string>();
+	it("does not forward flag registration to realPi and gates flag access through the capture shim", () => {
 		const pi = {
 			...createMockPi(),
-			registerFlag: vi.fn((name: string) => {
-				registeredFlags.add(name);
-			}),
-			getFlag: vi.fn((name: string) => {
-				return registeredFlags.has(name) ? "test-value" : undefined;
-			}),
+			getFlag: vi.fn((_name: string) => "test-value"),
 		};
 
 		const captured = new Map();
 		const shim = _test.buildCaptureShim(pi as unknown as ExtensionAPI, captured);
 
-		// Before registration, shim returns undefined
+		// Before registration, shim returns undefined (flag not tracked)
 		expect(shim.getFlag("--exa-mcp-tools")).toBeUndefined();
 
-		// After registration, shim forwards to real pi
+		// After registration, shim tracks in shimFlags and delegates getFlag to realPi
 		shim.registerFlag("--exa-mcp-tools", { description: "tools", type: "string" });
-		expect(pi.registerFlag).toHaveBeenCalledWith("--exa-mcp-tools", { description: "tools", type: "string" });
+		expect(pi.registerFlag).not.toHaveBeenCalled();
 		expect(shim.getFlag("--exa-mcp-tools")).toBe("test-value");
 
 		// Unregistered flags still return undefined through shim

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -1,0 +1,841 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import piClaudeCodeUse, { _test } from "../extensions/index.js";
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/** Build a minimal ToolInfo-compatible object for test mocks. */
+function mockTool(name: string, sourceOverrides?: { baseDir?: string; path?: string }) {
+	return {
+		name,
+		description: "",
+		parameters: {} as never,
+		sourceInfo: {
+			path: sourceOverrides?.path ?? "",
+			source: "test",
+			scope: "user" as const,
+			origin: "package" as const,
+			baseDir: sourceOverrides?.baseDir,
+		},
+	};
+}
+
+function createMockPi() {
+	return {
+		appendEntry: vi.fn(),
+		events: {} as ExtensionAPI["events"],
+		exec: vi.fn(),
+		getActiveTools: vi.fn((): string[] => []),
+		getAllTools: vi.fn((): ReturnType<ExtensionAPI["getAllTools"]> => []),
+		getCommands: vi.fn(() => []),
+		getFlag: vi.fn((_name?: string): boolean | string | undefined => undefined),
+		getSessionName: vi.fn(() => undefined as string | undefined),
+		getThinkingLevel: vi.fn(() => "medium"),
+		on: vi.fn(),
+		registerCommand: vi.fn(),
+		registerFlag: vi.fn(),
+		registerMessageRenderer: vi.fn(),
+		registerProvider: vi.fn(),
+		registerShortcut: vi.fn(),
+		registerTool: vi.fn(),
+		sendMessage: vi.fn(),
+		sendUserMessage: vi.fn(),
+		setActiveTools: vi.fn(),
+		setLabel: vi.fn(),
+		setModel: vi.fn(async () => true),
+		setSessionName: vi.fn(),
+		setThinkingLevel: vi.fn(),
+		unregisterProvider: vi.fn(),
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("pi-claude-code-use", () => {
+	beforeEach(() => {
+		_test.registeredMcpAliases.clear();
+		_test.autoActivatedAliases.clear();
+		_test.setLastManagedToolList(undefined);
+	});
+
+	// ----------------------------------------------------------------
+	// Extension lifecycle
+	// ----------------------------------------------------------------
+
+	it("registers event hooks without overriding the anthropic provider", async () => {
+		const pi = createMockPi();
+		await piClaudeCodeUse(pi as unknown as ExtensionAPI);
+
+		expect(pi.on).toHaveBeenCalledWith("session_start", expect.any(Function));
+		expect(pi.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
+		expect(pi.on).toHaveBeenCalledWith("before_provider_request", expect.any(Function));
+		expect(pi.registerProvider).not.toHaveBeenCalled();
+	});
+
+	it("does not call runtime-only APIs during extension factory load", async () => {
+		const pi = createMockPi();
+		pi.getAllTools.mockImplementation(() => {
+			throw new Error("runtime not ready");
+		});
+		pi.getActiveTools.mockImplementation(() => {
+			throw new Error("runtime not ready");
+		});
+
+		await expect(piClaudeCodeUse(pi as unknown as ExtensionAPI)).resolves.toBeUndefined();
+	});
+
+	it("does not register alias tools when no companion source tools are loaded", async () => {
+		const pi = createMockPi();
+		pi.getAllTools.mockReturnValue([mockTool("read")]);
+		await piClaudeCodeUse(pi as unknown as ExtensionAPI);
+
+		expect(pi.registerTool).not.toHaveBeenCalled();
+	});
+
+	// ----------------------------------------------------------------
+	// System prompt rewriting (PRD §1.1)
+	// ----------------------------------------------------------------
+
+	it("replaces 'pi itself' in string-form system prompts", () => {
+		const result = _test.transformPayload(
+			{
+				system: "Pi docs (read about pi itself and its SDK):",
+				messages: [{ role: "user", content: "hi" }],
+			},
+			false,
+		);
+
+		expect(result.system).toBe("Pi docs (read about the cli itself and its SDK):");
+	});
+
+	it("rewrites text blocks in array system prompts while preserving metadata", () => {
+		const result = _test.transformPayload(
+			{
+				system: [
+					{
+						type: "text",
+						text: "You are Claude Code, Anthropic's official CLI for Claude.",
+						cache_control: { type: "ephemeral", ttl: "1h" },
+					},
+					{
+						type: "text",
+						text: "Pi docs (read about pi itself, its SDK, extensions):",
+						cache_control: { type: "ephemeral", ttl: "1h" },
+					},
+				],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.system).toEqual([
+			{
+				type: "text",
+				text: "You are Claude Code, Anthropic's official CLI for Claude.",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+			{
+				type: "text",
+				text: "Pi docs (read about the cli itself, its SDK, extensions):",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+		]);
+	});
+
+	it("leaves non-text system blocks untouched", () => {
+		const guardBlock = { type: "guard_content", guard: "keep-me" };
+		const result = _test.transformPayload(
+			{
+				system: [{ type: "text", text: "about pi itself" }, guardBlock],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.system).toEqual([{ type: "text", text: "about the cli itself" }, guardBlock]);
+	});
+
+	it("handles multiple occurrences of 'pi itself' in one block", () => {
+		expect(_test.rewritePromptText("pi itself and pi itself again")).toBe("the cli itself and the cli itself again");
+	});
+
+	// ----------------------------------------------------------------
+	// Tool filtering and MCP alias remapping (PRD §1.2)
+	// ----------------------------------------------------------------
+
+	it("passes core tools, typed tools, and mcp__-prefixed tools through", () => {
+		const result = _test.transformPayload(
+			{
+				tools: [
+					{ name: "Read", description: "Read files", input_schema: {} },
+					{ type: "web_search", name: "web_search", search_context_size: "high" },
+					{ name: "mcp__custom__lookup", description: "Custom", input_schema: {} },
+					{ name: "unknown_flat_tool", description: "Should be dropped", input_schema: {} },
+				],
+				messages: [],
+			},
+			false,
+		);
+
+		const toolIds = (result.tools as { name?: string; type?: string }[]).map((t) => t.name ?? t.type);
+		expect(toolIds).toEqual(["Read", "web_search", "mcp__custom__lookup"]);
+	});
+
+	it("renames known companion tools to MCP aliases when alias is advertised", () => {
+		const result = _test.transformPayload(
+			{
+				tools: [
+					{ name: "web_search_exa", description: "Flat", input_schema: {} },
+					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+				],
+				messages: [],
+			},
+			false,
+		);
+
+		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual(["mcp__exa__web_search"]);
+	});
+
+	it("filters companion tools when MCP alias is not in the tool list", () => {
+		const result = _test.transformPayload(
+			{
+				tools: [{ name: "web_search_exa", description: "Orphan", input_schema: {} }],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.tools).toEqual([]);
+	});
+
+	it("passes all tools through unchanged when filter is disabled", () => {
+		const result = _test.transformPayload(
+			{
+				tools: [
+					{ name: "web_search_exa", description: "Flat", input_schema: {} },
+					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "totally_unknown", description: "Custom ext", input_schema: {} },
+				],
+				messages: [],
+			},
+			true,
+		);
+
+		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual([
+			"web_search_exa",
+			"mcp__exa__web_search",
+			"totally_unknown",
+		]);
+	});
+
+	// ----------------------------------------------------------------
+	// tool_choice remapping
+	// ----------------------------------------------------------------
+
+	it("remaps tool_choice from flat companion name to MCP alias", () => {
+		const result = _test.transformPayload(
+			{
+				tool_choice: { type: "tool", name: "web_search_exa" },
+				tools: [
+					{ name: "web_search_exa", input_schema: {} },
+					{ name: "mcp__exa__web_search", input_schema: {} },
+				],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.tool_choice).toEqual({ type: "tool", name: "mcp__exa__web_search" });
+	});
+
+	it("clears tool_choice when the referenced tool is filtered out", () => {
+		const result = _test.transformPayload(
+			{
+				tool_choice: { type: "tool", name: "unknown_tool" },
+				tools: [{ name: "unknown_tool", input_schema: {} }],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.tool_choice).toBeUndefined();
+	});
+
+	it("leaves non-tool tool_choice types unchanged", () => {
+		const surviving = new Map([["read", "Read"]]);
+		expect(_test.remapToolChoice({ type: "auto" }, surviving)).toEqual({ type: "auto" });
+		expect(_test.remapToolChoice({ type: "any" }, surviving)).toEqual({ type: "any" });
+	});
+
+	it("normalizes tool_choice casing to match advertised tool names", () => {
+		const result = _test.transformPayload(
+			{
+				tool_choice: { type: "tool", name: "read" },
+				tools: [{ name: "Read", description: "Read files", input_schema: {} }],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.tool_choice).toEqual({ type: "tool", name: "Read" });
+	});
+
+	// ----------------------------------------------------------------
+	// Historical tool_use message rewriting
+	// ----------------------------------------------------------------
+
+	it("renames tool_use blocks in message history when MCP alias survives filtering", () => {
+		const result = _test.transformPayload(
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "text", text: "Searching..." },
+							{ type: "tool_use", id: "toolu_abc", name: "web_search_exa", input: { q: "test" } },
+						],
+					},
+					{
+						role: "user",
+						content: [{ type: "tool_result", tool_use_id: "toolu_abc", content: "done" }],
+					},
+				],
+				tools: [
+					{ name: "web_search_exa", input_schema: {} },
+					{ name: "mcp__exa__web_search", input_schema: {} },
+				],
+			},
+			false,
+		);
+
+		expect(result.messages).toEqual([
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Searching..." },
+					{ type: "tool_use", id: "toolu_abc", name: "mcp__exa__web_search", input: { q: "test" } },
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "toolu_abc", content: "done" }],
+			},
+		]);
+	});
+
+	it("preserves tool_use names when no MCP alias survives filtering", () => {
+		const result = _test.transformPayload(
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "tool_use", id: "toolu_1", name: "web_search_exa", input: {} }],
+					},
+				],
+				tools: [{ name: "web_search_exa", input_schema: {} }],
+			},
+			false,
+		);
+
+		expect(result.messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_1", name: "web_search_exa", input: {} }],
+			},
+		]);
+	});
+
+	// ----------------------------------------------------------------
+	// Full payload integration
+	// ----------------------------------------------------------------
+
+	it("applies all transforms together: system rewrite, tool filter, tool_choice, messages", () => {
+		const result = _test.transformPayload(
+			{
+				model: "claude-opus-4-6",
+				system: [
+					{
+						type: "text",
+						text: "You are Claude Code.",
+						cache_control: { type: "ephemeral", ttl: "1h" },
+					},
+					{
+						type: "text",
+						text: "Pi docs (ask about pi itself):",
+						cache_control: { type: "ephemeral", ttl: "1h" },
+					},
+				],
+				messages: [{ role: "user", content: [{ type: "text", text: "Search for bugs" }] }],
+				tools: [
+					{ name: "Read", description: "Read files", input_schema: {} },
+					{ type: "web_search", name: "web_search", search_context_size: "high" },
+					{ name: "web_search_exa", description: "Exa", input_schema: {} },
+					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "mcp__custom__tool", description: "Custom", input_schema: {} },
+					{ name: "unknown_flat", description: "Dropped", input_schema: {} },
+				],
+			},
+			false,
+		);
+
+		expect(result.system).toEqual([
+			{
+				type: "text",
+				text: "You are Claude Code.",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+			{
+				type: "text",
+				text: "Pi docs (ask about the cli itself):",
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
+		]);
+
+		expect((result.tools as { name?: string; type?: string }[]).map((t) => t.name ?? t.type)).toEqual([
+			"Read",
+			"web_search",
+			"mcp__exa__web_search",
+			"mcp__custom__tool",
+		]);
+
+		// Must not inject metadata (that's Tier 2)
+		expect("metadata" in result).toBe(false);
+	});
+
+	it("passes tools, tool_choice, and messages through unchanged with filter disabled", () => {
+		const result = _test.transformPayload(
+			{
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "tool_use", id: "toolu_x", name: "web_search_exa", input: { q: "pi" } }],
+					},
+				],
+				tool_choice: { type: "tool", name: "web_search_exa" },
+				tools: [
+					{ name: "web_search_exa", description: "Flat", input_schema: {} },
+					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "custom_ext_tool", description: "Custom", input_schema: {} },
+				],
+			},
+			true,
+		);
+
+		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual([
+			"web_search_exa",
+			"mcp__exa__web_search",
+			"custom_ext_tool",
+		]);
+		expect(result.tool_choice).toEqual({ type: "tool", name: "web_search_exa" });
+		expect(result.messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_x", name: "web_search_exa", input: { q: "pi" } }],
+			},
+		]);
+	});
+
+	// ----------------------------------------------------------------
+	// Companion source matching
+	// ----------------------------------------------------------------
+
+	it("matches companion source by directory name from package root", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						baseDir: "/tmp/node_modules/@benvargas/pi-exa-mcp",
+						path: "/tmp/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+					},
+				} as never,
+				spec,
+			),
+		).toBe(true);
+	});
+
+	it("matches companion source from extensions/ subdirectory layout", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						baseDir: "/worktree/packages/pi-exa-mcp/extensions",
+						path: "/worktree/packages/pi-exa-mcp/extensions/index.ts",
+					},
+				} as never,
+				spec,
+			),
+		).toBe(true);
+	});
+
+	it("rejects tools from unrelated extension directories", () => {
+		const spec = {
+			dirName: "pi-antigravity-image-gen",
+			packageName: "@benvargas/pi-antigravity-image-gen",
+			aliases: [] as const,
+		};
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "generate_image",
+					sourceInfo: {
+						baseDir: "/tmp/some-other-extension",
+						path: "/tmp/some-other-extension/extensions/index.ts",
+					},
+				} as never,
+				spec,
+			),
+		).toBe(false);
+	});
+
+	it("matches companion source via path when baseDir is absent", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						path: "/worktree/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+						source: "test",
+						scope: "user" as const,
+						origin: "package" as const,
+					},
+				} as never,
+				spec,
+			),
+		).toBe(true);
+	});
+
+	it("rejects tools from packages whose names are prefixes of the companion package", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						path: "/worktree/node_modules/@benvargas/pi-exa-mcp-wrapper/extensions/index.ts",
+						source: "test",
+						scope: "user" as const,
+						origin: "package" as const,
+					},
+				} as never,
+				spec,
+			),
+		).toBe(false);
+	});
+
+	it("matches companion source via dirName fallback for monorepo/git installs", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						// baseDir is the monorepo root, not the individual package
+						baseDir: "/home/user/.pi/agent/git/github.com/ben-vargas/pi-packages",
+						path: "/home/user/.pi/agent/git/github.com/ben-vargas/pi-packages/packages/pi-exa-mcp/extensions/index.ts",
+						source: "test",
+						scope: "user" as const,
+						origin: "package" as const,
+					},
+				} as never,
+				spec,
+			),
+		).toBe(true);
+	});
+
+	it("matches companion source via Windows-style backslash paths", () => {
+		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
+		expect(
+			_test.isCompanionSource(
+				{
+					name: "web_search_exa",
+					sourceInfo: {
+						path: "C:\\Users\\dev\\node_modules\\@benvargas\\pi-exa-mcp\\extensions\\index.ts",
+						source: "test",
+						scope: "user" as const,
+						origin: "package" as const,
+					},
+				} as never,
+				spec,
+			),
+		).toBe(true);
+	});
+
+	// ----------------------------------------------------------------
+	// Alias activation tracking
+	// ----------------------------------------------------------------
+
+	it("activates MCP aliases for active companion tools, then removes them on disable", () => {
+		const pi = createMockPi();
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		// Now disable: should remove the alias
+		pi.setActiveTools.mockClear();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa"]);
+	});
+
+	it("does not remove non-extension MCP tools when disabling aliases", () => {
+		const pi = createMockPi();
+		// This MCP tool was NOT registered by our extension (registeredMcpAliases is empty)
+		pi.getAllTools.mockReturnValue([mockTool("mcp__exa__web_search")]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+	});
+
+	it("preserves user-selected aliases when disabling auto-activation", () => {
+		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		// Only mcp__firecrawl__scrape was auto-activated; mcp__exa__web_search was user-selected
+		_test.autoActivatedAliases.add("mcp__firecrawl__scrape");
+		_test.registeredMcpAliases.add("mcp__firecrawl__scrape");
+
+		pi.getAllTools.mockReturnValue([mockTool("mcp__exa__web_search"), mockTool("mcp__firecrawl__scrape")]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search", "mcp__firecrawl__scrape"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+		// Should remove auto-activated mcp__firecrawl__scrape but keep user-selected mcp__exa__web_search
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "mcp__exa__web_search"]);
+	});
+
+	it("prunes auto-activated aliases when their flat counterpart is no longer active", () => {
+		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		_test.autoActivatedAliases.add("mcp__exa__web_search");
+		_test.setLastManagedToolList(["read", "mcp__exa__web_search"]);
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		// web_search_exa is NOT active, only the alias is (stale state)
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("preserves aliases the user explicitly enabled via the tool picker", () => {
+		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		// Alias is NOT in autoActivatedAliases → user added it manually
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		// web_search_exa is not active, but user manually enabled the MCP alias
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		// User-selected alias is preserved even without flat counterpart active
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+	});
+
+	it("promotes auto-activated alias to user-selected when user removes flat but keeps alias", () => {
+		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		_test.autoActivatedAliases.add("mcp__exa__web_search");
+		// Last sync had both flat + alias active
+		_test.setLastManagedToolList(["read", "web_search_exa", "mcp__exa__web_search"]);
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		// User removed web_search_exa (was in last managed) but kept the MCP alias
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		// Alias promoted to user-selected → preserved even though flat is inactive
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+	});
+
+	it("prunes auto-activated aliases when flat was never managed (no promotion)", () => {
+		const pi = createMockPi();
+		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		_test.autoActivatedAliases.add("mcp__exa__web_search");
+		// Last sync did NOT include web_search_exa → flat was never managed
+		_test.setLastManagedToolList(["read", "mcp__exa__web_search"]);
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		// Flat was never in managed list → no promotion, alias is pruned
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	// ----------------------------------------------------------------
+	// Capture shim
+	// ----------------------------------------------------------------
+
+	it("forwards flag registration and gates flag access through the capture shim", () => {
+		const registeredFlags = new Set<string>();
+		const pi = {
+			...createMockPi(),
+			registerFlag: vi.fn((name: string) => {
+				registeredFlags.add(name);
+			}),
+			getFlag: vi.fn((name: string) => {
+				return registeredFlags.has(name) ? "test-value" : undefined;
+			}),
+		};
+
+		const captured = new Map();
+		const shim = _test.buildCaptureShim(pi as unknown as ExtensionAPI, captured);
+
+		// Before registration, shim returns undefined
+		expect(shim.getFlag("--exa-mcp-tools")).toBeUndefined();
+
+		// After registration, shim forwards to real pi
+		shim.registerFlag("--exa-mcp-tools", { description: "tools", type: "string" });
+		expect(pi.registerFlag).toHaveBeenCalledWith("--exa-mcp-tools", { description: "tools", type: "string" });
+		expect(shim.getFlag("--exa-mcp-tools")).toBe("test-value");
+
+		// Unregistered flags still return undefined through shim
+		expect(shim.getFlag("--other-flag")).toBeUndefined();
+	});
+
+	// ----------------------------------------------------------------
+	// before_provider_request handler (end-to-end)
+	// ----------------------------------------------------------------
+
+	async function getProviderRequestHandler(pi: ReturnType<typeof createMockPi>) {
+		await piClaudeCodeUse(pi as unknown as ExtensionAPI);
+		const hookCall = pi.on.mock.calls.find((c: unknown[]) => c[0] === "before_provider_request");
+		return hookCall?.[1] as (event: { payload: unknown }, ctx: Record<string, unknown>) => unknown;
+	}
+
+	it("transforms payload when model is anthropic OAuth", async () => {
+		const pi = createMockPi();
+		const handler = await getProviderRequestHandler(pi);
+
+		const ctx = {
+			model: { provider: "anthropic", id: "claude-opus-4-6" },
+			modelRegistry: { isUsingOAuth: () => true },
+		};
+
+		const result = handler(
+			{
+				payload: {
+					system: "ask about pi itself",
+					tools: [
+						{ name: "Read", description: "Read", input_schema: {} },
+						{ name: "unknown_flat", description: "Drop", input_schema: {} },
+					],
+					messages: [{ role: "user", content: "hi" }],
+				},
+			},
+			ctx,
+		);
+
+		expect(result).toBeDefined();
+		const p = result as Record<string, unknown>;
+		expect(p.system).toBe("ask about the cli itself");
+		expect((p.tools as { name: string }[]).map((t) => t.name)).toEqual(["Read"]);
+	});
+
+	it("returns undefined for non-anthropic models", async () => {
+		const pi = createMockPi();
+		const handler = await getProviderRequestHandler(pi);
+
+		const ctx = {
+			model: { provider: "openai", id: "gpt-5.4" },
+			modelRegistry: { isUsingOAuth: () => false },
+		};
+
+		const result = handler(
+			{
+				payload: {
+					system: "ask about pi itself",
+					tools: [{ name: "unknown_flat", description: "Keep", input_schema: {} }],
+					messages: [],
+				},
+			},
+			ctx,
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined for anthropic non-OAuth models", async () => {
+		const pi = createMockPi();
+		const handler = await getProviderRequestHandler(pi);
+
+		const ctx = {
+			model: { provider: "anthropic", id: "claude-opus-4-6" },
+			modelRegistry: { isUsingOAuth: () => false },
+		};
+
+		const result = handler({ payload: { system: "pi itself", tools: [], messages: [] } }, ctx);
+
+		expect(result).toBeUndefined();
+	});
+
+	// ----------------------------------------------------------------
+	// Companion loading integration
+	// ----------------------------------------------------------------
+
+	it("registers MCP alias tools from companion extension factories", async () => {
+		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		const tempRoot = join(tempParent, "pi-exa-mcp");
+		try {
+			const extDir = join(tempRoot, "extensions");
+			mkdirSync(extDir, { recursive: true });
+			writeFileSync(
+				join(extDir, "index.js"),
+				[
+					'import { StringEnum } from "@mariozechner/pi-ai";',
+					'import { DEFAULT_MAX_BYTES } from "@mariozechner/pi-coding-agent";',
+					'import { Type } from "@sinclair/typebox";',
+					"const schema = Type.Object({ q: StringEnum(['web']) });",
+					"export default function companion(pi) {",
+					"  pi.registerTool({",
+					'    name: "web_search_exa",',
+					"    description: 'Search web ' + String(DEFAULT_MAX_BYTES),",
+					"    inputSchema: schema,",
+					"    async execute() { return { content: [{ type: 'text', text: String(DEFAULT_MAX_BYTES) }] }; }",
+					"  });",
+					"}",
+				].join("\n"),
+				"utf-8",
+			);
+
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { baseDir: tempRoot, path: join(extDir, "index.js") }),
+			]);
+
+			await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI);
+
+			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__exa__web_search" }));
+		} finally {
+			rmSync(tempParent, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to alias tools from unrelated packages even if names match", async () => {
+		const pi = createMockPi();
+		pi.getAllTools.mockReturnValue([
+			mockTool("generate_image", {
+				baseDir: "/tmp/node_modules/some-random-ext",
+				path: "/tmp/node_modules/some-random-ext/extensions/index.ts",
+			}),
+		]);
+
+		await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI);
+		expect(pi.registerTool).not.toHaveBeenCalled();
+	});
+});

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -1,0 +1,639 @@
+import { appendFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import { createJiti } from "@mariozechner/jiti";
+import * as piAiModule from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import * as piCodingAgentModule from "@mariozechner/pi-coding-agent";
+import * as typeboxModule from "@sinclair/typebox";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CompanionSpec {
+	dirName: string;
+	packageName: string;
+	aliases: ReadonlyArray<readonly [flatName: string, mcpName: string]>;
+}
+
+type ToolRegistration = Parameters<ExtensionAPI["registerTool"]>[0];
+type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Core Claude Code tool names that always pass through Anthropic OAuth filtering.
+ * Stored lowercase for case-insensitive matching.
+ * Mirrors Pi core's claudeCodeTools list in packages/ai/src/providers/anthropic.ts
+ */
+const CORE_TOOL_NAMES = new Set([
+	"read",
+	"write",
+	"edit",
+	"bash",
+	"grep",
+	"glob",
+	"askuserquestion",
+	"enterplanmode",
+	"exitplanmode",
+	"killshell",
+	"notebookedit",
+	"skill",
+	"task",
+	"taskoutput",
+	"todowrite",
+	"webfetch",
+	"websearch",
+]);
+
+/** Flat companion tool name → MCP-style alias. */
+const FLAT_TO_MCP = new Map<string, string>([
+	["web_search_exa", "mcp__exa__web_search"],
+	["get_code_context_exa", "mcp__exa__get_code_context"],
+	["firecrawl_scrape", "mcp__firecrawl__scrape"],
+	["firecrawl_map", "mcp__firecrawl__map"],
+	["firecrawl_search", "mcp__firecrawl__search"],
+	["generate_image", "mcp__antigravity__generate_image"],
+	["image_quota", "mcp__antigravity__image_quota"],
+]);
+
+/** Known companion extensions and the tools they provide. */
+const COMPANIONS: CompanionSpec[] = [
+	{
+		dirName: "pi-exa-mcp",
+		packageName: "@benvargas/pi-exa-mcp",
+		aliases: [
+			["web_search_exa", "mcp__exa__web_search"],
+			["get_code_context_exa", "mcp__exa__get_code_context"],
+		],
+	},
+	{
+		dirName: "pi-firecrawl",
+		packageName: "@benvargas/pi-firecrawl",
+		aliases: [
+			["firecrawl_scrape", "mcp__firecrawl__scrape"],
+			["firecrawl_map", "mcp__firecrawl__map"],
+			["firecrawl_search", "mcp__firecrawl__search"],
+		],
+	},
+	{
+		dirName: "pi-antigravity-image-gen",
+		packageName: "@benvargas/pi-antigravity-image-gen",
+		aliases: [
+			["generate_image", "mcp__antigravity__generate_image"],
+			["image_quota", "mcp__antigravity__image_quota"],
+		],
+	},
+];
+
+/** Reverse lookup: flat tool name → its companion spec. */
+const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
+	COMPANIONS.flatMap((spec) => spec.aliases.map(([flat]) => [flat, spec] as const)),
+);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function lower(name: string | undefined): string {
+	return (name ?? "").trim().toLowerCase();
+}
+
+// ============================================================================
+// System prompt rewrite (PRD §1.1)
+//
+// Replace "pi itself" → "the cli itself" in system prompt text.
+// Preserves cache_control, non-text blocks, and payload shape.
+// ============================================================================
+
+function rewritePromptText(text: string): string {
+	return text.replaceAll("pi itself", "the cli itself");
+}
+
+function rewriteSystemField(system: unknown): unknown {
+	if (typeof system === "string") {
+		return rewritePromptText(system);
+	}
+	if (!Array.isArray(system)) {
+		return system;
+	}
+	return system.map((block) => {
+		if (!isPlainObject(block) || block.type !== "text" || typeof block.text !== "string") {
+			return block;
+		}
+		const rewritten = rewritePromptText(block.text);
+		return rewritten === block.text ? block : { ...block, text: rewritten };
+	});
+}
+
+// ============================================================================
+// Tool filtering and MCP alias remapping (PRD §1.2)
+//
+// Rules applied per tool:
+// 1. Anthropic-native typed tools (have a `type` field) → pass through
+// 2. Core Claude Code tool names → pass through
+// 3. Tools already prefixed with mcp__ → pass through
+// 4. Known companion tools whose MCP alias is also advertised → rename to alias
+// 5. Known companion tools without an advertised alias → filtered out
+// 6. Unknown flat-named tools → filtered out (unless disableFilter)
+// ============================================================================
+
+function collectToolNames(tools: unknown[]): Set<string> {
+	const names = new Set<string>();
+	for (const tool of tools) {
+		if (isPlainObject(tool) && typeof tool.name === "string") {
+			names.add(lower(tool.name));
+		}
+	}
+	return names;
+}
+
+function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolean): unknown[] | undefined {
+	if (!Array.isArray(tools)) return tools;
+
+	const advertised = collectToolNames(tools);
+	const emitted = new Set<string>();
+	const result: unknown[] = [];
+
+	for (const tool of tools) {
+		if (!isPlainObject(tool)) continue;
+
+		// Rule 1: native typed tools always pass through
+		if (typeof tool.type === "string" && tool.type.trim().length > 0) {
+			result.push(tool);
+			continue;
+		}
+
+		const name = typeof tool.name === "string" ? tool.name : "";
+		if (!name) continue;
+		const nameLc = lower(name);
+
+		// Rules 2 & 3: core tools and mcp__-prefixed pass through (with dedup)
+		if (CORE_TOOL_NAMES.has(nameLc) || nameLc.startsWith("mcp__")) {
+			if (!emitted.has(nameLc)) {
+				emitted.add(nameLc);
+				result.push(tool);
+			}
+			continue;
+		}
+
+		// Rules 4 & 5: known companion tool
+		const mcpAlias = FLAT_TO_MCP.get(nameLc);
+		if (mcpAlias) {
+			const aliasLc = lower(mcpAlias);
+			if (advertised.has(aliasLc) && !emitted.has(aliasLc)) {
+				// Alias exists in tool list → rename flat to alias, dedup
+				emitted.add(aliasLc);
+				result.push({ ...tool, name: mcpAlias });
+			} else if (disableFilter && !emitted.has(nameLc)) {
+				// Filter disabled: keep flat name if not yet emitted
+				emitted.add(nameLc);
+				result.push(tool);
+			}
+			continue;
+		}
+
+		// Rule 6: unknown flat-named tool
+		if (disableFilter && !emitted.has(nameLc)) {
+			emitted.add(nameLc);
+			result.push(tool);
+		}
+	}
+
+	return result;
+}
+
+function remapToolChoice(
+	toolChoice: Record<string, unknown>,
+	survivingNames: Map<string, string>,
+): Record<string, unknown> | undefined {
+	if (toolChoice.type !== "tool" || typeof toolChoice.name !== "string") {
+		return toolChoice;
+	}
+
+	const nameLc = lower(toolChoice.name);
+	const actualName = survivingNames.get(nameLc);
+	if (actualName) {
+		return actualName === toolChoice.name ? toolChoice : { ...toolChoice, name: actualName };
+	}
+
+	const mcpAlias = FLAT_TO_MCP.get(nameLc);
+	if (mcpAlias && survivingNames.has(lower(mcpAlias))) {
+		return { ...toolChoice, name: mcpAlias };
+	}
+
+	return undefined;
+}
+
+function remapMessageToolNames(messages: unknown[], survivingNames: Map<string, string>): unknown[] {
+	let anyChanged = false;
+	const result = messages.map((msg) => {
+		if (!isPlainObject(msg) || !Array.isArray(msg.content)) return msg;
+
+		let msgChanged = false;
+		const content = (msg.content as unknown[]).map((block) => {
+			if (!isPlainObject(block) || block.type !== "tool_use" || typeof block.name !== "string") {
+				return block;
+			}
+			const mcpAlias = FLAT_TO_MCP.get(lower(block.name));
+			if (mcpAlias && survivingNames.has(lower(mcpAlias))) {
+				msgChanged = true;
+				return { ...block, name: mcpAlias };
+			}
+			return block;
+		});
+
+		if (msgChanged) {
+			anyChanged = true;
+			return { ...msg, content };
+		}
+		return msg;
+	});
+
+	return anyChanged ? result : messages;
+}
+
+// ============================================================================
+// Full payload transform
+// ============================================================================
+
+function transformPayload(raw: Record<string, unknown>, disableFilter: boolean): Record<string, unknown> {
+	// Deep clone to avoid mutating the original
+	const payload = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+
+	// 1. System prompt rewrite (always applies)
+	if (payload.system !== undefined) {
+		payload.system = rewriteSystemField(payload.system);
+	}
+
+	// When escape hatch is active, skip all tool filtering/remapping
+	if (disableFilter) {
+		return payload;
+	}
+
+	// 2. Tool filtering and alias remapping
+	payload.tools = filterAndRemapTools(payload.tools as unknown[] | undefined, false);
+
+	// 3. Build map of tool names that survived filtering (lowercase → actual name)
+	const survivingNames = new Map<string, string>();
+	if (Array.isArray(payload.tools)) {
+		for (const tool of payload.tools) {
+			if (isPlainObject(tool) && typeof tool.name === "string") {
+				survivingNames.set(lower(tool.name), tool.name as string);
+			}
+		}
+	}
+
+	// 4. Remap tool_choice if it references a renamed or filtered tool
+	if (isPlainObject(payload.tool_choice)) {
+		const remapped = remapToolChoice(payload.tool_choice, survivingNames);
+		if (remapped === undefined) {
+			delete payload.tool_choice;
+		} else {
+			payload.tool_choice = remapped;
+		}
+	}
+
+	// 5. Rewrite historical tool_use blocks in message history
+	if (Array.isArray(payload.messages)) {
+		payload.messages = remapMessageToolNames(payload.messages, survivingNames);
+	}
+
+	return payload;
+}
+
+// ============================================================================
+// Debug logging (PRD §1.4)
+// ============================================================================
+
+const debugLogPath = process.env.PI_CLAUDE_CODE_USE_DEBUG_LOG;
+
+function writeDebugLog(payload: unknown): void {
+	if (!debugLogPath) return;
+	try {
+		appendFileSync(debugLogPath, `${new Date().toISOString()}\n${JSON.stringify(payload, null, 2)}\n---\n`, "utf-8");
+	} catch {
+		// Debug logging must never break actual requests
+	}
+}
+
+// ============================================================================
+// Companion alias registration (PRD §1.3)
+//
+// Discovers loaded companion extensions, captures their tool definitions via
+// a shim ExtensionAPI, and registers MCP-alias versions so the model can
+// invoke them under Claude Code-compatible names.
+// ============================================================================
+
+const registeredMcpAliases = new Set<string>();
+const autoActivatedAliases = new Set<string>();
+let lastManagedToolList: string[] | undefined;
+
+const captureCache = new Map<string, Promise<Map<string, ToolRegistration>>>();
+let jitiLoader: { import(path: string, opts?: { default?: boolean }): Promise<unknown> } | undefined;
+
+function getJitiLoader() {
+	if (!jitiLoader) {
+		jitiLoader = createJiti(import.meta.url, {
+			moduleCache: false,
+			tryNative: false,
+			virtualModules: {
+				"@mariozechner/pi-ai": piAiModule,
+				"@mariozechner/pi-coding-agent": piCodingAgentModule,
+				"@sinclair/typebox": typeboxModule,
+			},
+		});
+	}
+	return jitiLoader;
+}
+
+async function loadFactory(baseDir: string): Promise<((pi: ExtensionAPI) => void | Promise<void>) | undefined> {
+	const dir = baseDir.replace(/\/$/, "");
+	const candidates = [`${dir}/index.ts`, `${dir}/index.js`, `${dir}/extensions/index.ts`, `${dir}/extensions/index.js`];
+
+	const loader = getJitiLoader();
+	for (const path of candidates) {
+		try {
+			const mod = await loader.import(path, { default: true });
+			if (typeof mod === "function") return mod as (pi: ExtensionAPI) => void | Promise<void>;
+		} catch {
+			// Try next candidate
+		}
+	}
+	return undefined;
+}
+
+function isCompanionSource(tool: ToolInfo | undefined, spec: CompanionSpec): boolean {
+	if (!tool?.sourceInfo) return false;
+
+	const baseDir = tool.sourceInfo.baseDir;
+	if (baseDir) {
+		const dirName = basename(baseDir);
+		if (dirName === spec.dirName) return true;
+		if (dirName === "extensions" && basename(dirname(baseDir)) === spec.dirName) return true;
+	}
+
+	const fullPath = tool.sourceInfo.path;
+	if (typeof fullPath !== "string") return false;
+	// Normalize backslashes for Windows paths before segment-bounded check
+	const normalized = fullPath.replaceAll("\\", "/");
+	// Check for scoped package name (npm install) or directory name (git/monorepo)
+	return normalized.includes(`/${spec.packageName}/`) || normalized.includes(`/${spec.dirName}/`);
+}
+
+function buildCaptureShim(realPi: ExtensionAPI, captured: Map<string, ToolRegistration>): ExtensionAPI {
+	const shimFlags = new Set<string>();
+	return {
+		registerTool(def) {
+			captured.set(def.name, def as unknown as ToolRegistration);
+		},
+		registerFlag(name, options) {
+			shimFlags.add(name);
+			realPi.registerFlag(name, options);
+		},
+		getFlag(name) {
+			return shimFlags.has(name) ? realPi.getFlag(name) : undefined;
+		},
+		on() {},
+		registerCommand() {},
+		registerShortcut() {},
+		registerMessageRenderer() {},
+		registerProvider() {},
+		unregisterProvider() {},
+		sendMessage() {},
+		sendUserMessage() {},
+		appendEntry() {},
+		setSessionName() {},
+		getSessionName() {
+			return undefined;
+		},
+		setLabel() {},
+		exec(command, args, options) {
+			return realPi.exec(command, args, options);
+		},
+		getActiveTools() {
+			return realPi.getActiveTools();
+		},
+		getAllTools() {
+			return realPi.getAllTools();
+		},
+		setActiveTools(names) {
+			realPi.setActiveTools(names);
+		},
+		getCommands() {
+			return realPi.getCommands();
+		},
+		setModel(model) {
+			return realPi.setModel(model);
+		},
+		getThinkingLevel() {
+			return realPi.getThinkingLevel();
+		},
+		setThinkingLevel(level) {
+			realPi.setThinkingLevel(level);
+		},
+		events: realPi.events,
+	} as ExtensionAPI;
+}
+
+async function captureCompanionTools(baseDir: string, realPi: ExtensionAPI): Promise<Map<string, ToolRegistration>> {
+	let pending = captureCache.get(baseDir);
+	if (!pending) {
+		pending = (async () => {
+			const factory = await loadFactory(baseDir);
+			if (!factory) return new Map<string, ToolRegistration>();
+			const tools = new Map<string, ToolRegistration>();
+			await factory(buildCaptureShim(realPi, tools));
+			return tools;
+		})();
+		captureCache.set(baseDir, pending);
+	}
+	return pending;
+}
+
+async function registerAliasesForLoadedCompanions(pi: ExtensionAPI): Promise<void> {
+	// Clear capture cache so flag/config changes since last call take effect
+	captureCache.clear();
+
+	const allTools = pi.getAllTools();
+	const toolIndex = new Map<string, ToolInfo>();
+	const knownNames = new Set<string>();
+	for (const tool of allTools) {
+		toolIndex.set(lower(tool.name), tool);
+		knownNames.add(lower(tool.name));
+	}
+
+	for (const spec of COMPANIONS) {
+		for (const [flatName, mcpName] of spec.aliases) {
+			if (registeredMcpAliases.has(mcpName) || knownNames.has(lower(mcpName))) continue;
+
+			const tool = toolIndex.get(lower(flatName));
+			if (!tool || !isCompanionSource(tool, spec)) continue;
+
+			// Prefer the extension file's directory for loading (sourceInfo.path is the actual
+			// entry point). Fall back to baseDir only if path is unavailable. baseDir can be
+			// the monorepo root which doesn't contain the extension entry point directly.
+			const loadDir = tool.sourceInfo?.path ? dirname(tool.sourceInfo.path) : tool.sourceInfo?.baseDir;
+			if (!loadDir) continue;
+
+			const captured = await captureCompanionTools(loadDir, pi);
+			const def = captured.get(flatName);
+			if (!def) continue;
+
+			pi.registerTool({
+				...def,
+				name: mcpName,
+				label: def.label?.startsWith("MCP ") ? def.label : `MCP ${def.label ?? mcpName}`,
+			});
+			registeredMcpAliases.add(mcpName);
+			knownNames.add(lower(mcpName));
+		}
+	}
+}
+
+/**
+ * Synchronize MCP alias tool activation with the current model state.
+ * When OAuth is active, auto-activate aliases for any active companion tools.
+ * When OAuth is inactive, remove auto-activated aliases (but preserve user-selected ones).
+ */
+function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
+	const activeNames = pi.getActiveTools();
+	const allNames = new Set(pi.getAllTools().map((t) => t.name));
+
+	if (enableAliases) {
+		// Determine which aliases should be active based on their flat counterpart being active
+		const activeLc = new Set(activeNames.map(lower));
+		const desiredAliases: string[] = [];
+		for (const [flat, mcp] of FLAT_TO_MCP) {
+			if (activeLc.has(flat) && allNames.has(mcp)) {
+				desiredAliases.push(mcp);
+			}
+		}
+		const desiredSet = new Set(desiredAliases);
+
+		// Promote auto-activated aliases to user-selected when the user explicitly kept
+		// the alias while removing its flat counterpart from the tool picker.
+		// We detect this by checking: (a) user changed the tool list since our last sync,
+		// (b) the flat tool was previously managed but is no longer active, and
+		// (c) the alias is still active. This means the user deliberately kept the alias.
+		if (lastManagedToolList !== undefined) {
+			const activeSet = new Set(activeNames);
+			const lastManaged = new Set(lastManagedToolList);
+			for (const alias of autoActivatedAliases) {
+				if (!activeSet.has(alias) || desiredSet.has(alias)) continue;
+				// Find the flat name for this alias
+				const flatName = [...FLAT_TO_MCP.entries()].find(([, mcp]) => mcp === alias)?.[0];
+				if (flatName && lastManaged.has(flatName) && !activeSet.has(flatName)) {
+					// User removed the flat tool but kept the alias → promote to user-selected
+					autoActivatedAliases.delete(alias);
+				}
+			}
+		}
+
+		// Find registered aliases currently in the active list
+		const activeRegistered = activeNames.filter((n) => registeredMcpAliases.has(n) && allNames.has(n));
+
+		// Per-alias provenance: an alias is "user-selected" if it's active and was NOT
+		// auto-activated by us. Only preserve those; auto-activated aliases get re-derived
+		// from the desired set each sync.
+		const preserved = activeRegistered.filter((n) => !autoActivatedAliases.has(n));
+
+		// Build result: non-alias tools + preserved user aliases + desired aliases
+		const nonAlias = activeNames.filter((n) => !registeredMcpAliases.has(n));
+		const next = Array.from(new Set([...nonAlias, ...preserved, ...desiredAliases]));
+
+		// Update auto-activation tracking: aliases we added this sync that weren't user-preserved
+		const preservedSet = new Set(preserved);
+		autoActivatedAliases.clear();
+		for (const name of desiredAliases) {
+			if (!preservedSet.has(name)) {
+				autoActivatedAliases.add(name);
+			}
+		}
+
+		if (next.length !== activeNames.length || next.some((n, i) => n !== activeNames[i])) {
+			pi.setActiveTools(next);
+			lastManagedToolList = [...next];
+		}
+	} else {
+		// Remove only auto-activated aliases; user-selected ones are preserved
+		const next = activeNames.filter((n) => !autoActivatedAliases.has(n));
+		autoActivatedAliases.clear();
+
+		if (next.length !== activeNames.length || next.some((n, i) => n !== activeNames[i])) {
+			pi.setActiveTools(next);
+			lastManagedToolList = [...next];
+		} else {
+			lastManagedToolList = undefined;
+		}
+	}
+}
+
+// ============================================================================
+// Extension entry point
+// ============================================================================
+
+export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
+	pi.on("session_start", async () => {
+		await registerAliasesForLoadedCompanions(pi);
+	});
+
+	pi.on("before_agent_start", async (_event, ctx) => {
+		await registerAliasesForLoadedCompanions(pi);
+		const model = ctx.model;
+		const isOAuth = model?.provider === "anthropic" && ctx.modelRegistry.isUsingOAuth(model);
+		syncAliasActivation(pi, isOAuth);
+	});
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const model = ctx.model;
+		if (!model || model.provider !== "anthropic" || !ctx.modelRegistry.isUsingOAuth(model)) {
+			return undefined;
+		}
+		if (!isPlainObject(event.payload)) {
+			return undefined;
+		}
+
+		writeDebugLog({ stage: "before", payload: event.payload });
+		const disableFilter = process.env.PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER === "1";
+		const transformed = transformPayload(event.payload as Record<string, unknown>, disableFilter);
+		writeDebugLog({ stage: "after", payload: transformed });
+		return transformed;
+	});
+}
+
+// ============================================================================
+// Test exports
+// ============================================================================
+
+export const _test = {
+	CORE_TOOL_NAMES,
+	FLAT_TO_MCP,
+	COMPANIONS,
+	TOOL_TO_COMPANION,
+	autoActivatedAliases,
+	buildCaptureShim,
+	collectToolNames,
+	filterAndRemapTools,
+	getLastManagedToolList: () => lastManagedToolList,
+	isCompanionSource,
+	isPlainObject,
+	lower,
+	registerAliasesForLoadedCompanions,
+	registeredMcpAliases,
+	remapMessageToolNames,
+	remapToolChoice,
+	rewritePromptText,
+	rewriteSystemField,
+	setLastManagedToolList: (v: string[] | undefined) => {
+		lastManagedToolList = v;
+	},
+	syncAliasActivation,
+	transformPayload,
+};

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -393,9 +393,8 @@ function buildCaptureShim(realPi: ExtensionAPI, captured: Map<string, ToolRegist
 		registerTool(def) {
 			captured.set(def.name, def as unknown as ToolRegistration);
 		},
-		registerFlag(name, options) {
+		registerFlag(name, _options) {
 			shimFlags.add(name);
-			realPi.registerFlag(name, options);
 		},
 		getFlag(name) {
 			return shimFlags.has(name) ? realPi.getFlag(name) : undefined;
@@ -511,7 +510,7 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		const activeLc = new Set(activeNames.map(lower));
 		const desiredAliases: string[] = [];
 		for (const [flat, mcp] of FLAT_TO_MCP) {
-			if (activeLc.has(flat) && allNames.has(mcp)) {
+			if (activeLc.has(flat) && allNames.has(mcp) && registeredMcpAliases.has(mcp)) {
 				desiredAliases.push(mcp);
 			}
 		}

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@benvargas/pi-claude-code-use",
+  "version": "1.0.0",
+  "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
+  "keywords": [
+    "pi",
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "anthropic",
+    "claude",
+    "claude-code",
+    "oauth",
+    "subscription"
+  ],
+  "type": "module",
+  "files": [
+    "extensions/",
+    "README.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions/index.ts"
+    ]
+  },
+  "dependencies": {
+    "@mariozechner/jiti": "^2.6.5",
+    "@mariozechner/pi-ai": "*",
+    "@sinclair/typebox": "*"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.57.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ben-vargas/pi-packages.git",
+    "directory": "packages/pi-claude-code-use"
+  },
+  "author": "Ben Vargas",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ben-vargas/pi-packages/issues"
+  },
+  "homepage": "https://github.com/ben-vargas/pi-packages/tree/main/packages/pi-claude-code-use#readme"
+}


### PR DESCRIPTION
## Summary

- Adds `pi-claude-code-use`, an extension that transforms outbound Anthropic OAuth API payloads so Pi works seamlessly with Anthropic subscription tokens (`sk-ant-oat-*`) without triggering third-party usage classification.
- Rewrites `"pi itself"` → `"the cli itself"` in system prompts, filters unknown flat-named tools, and remaps companion tools (exa, firecrawl, antigravity) to MCP-prefixed aliases (`mcp__exa__web_search`, etc.).
- Works entirely via hooks (`before_provider_request`, `before_agent_start`, `session_start`) — does not register a new provider or replace Pi's Anthropic transport.
- Non-OAuth and non-Anthropic providers pass through completely unmodified.

## What's included

- `packages/pi-claude-code-use/extensions/index.ts` — 640 lines, handles system prompt rewriting, tool filtering/remapping, companion discovery via jiti capture shim, and alias activation tracking with per-alias provenance
- `packages/pi-claude-code-use/__tests__/index.test.ts` — 39 tests covering payload transforms, companion source matching (npm, monorepo, git, Windows paths), alias lifecycle, capture shim, and end-to-end handler behavior
- `packages/pi-claude-code-use/README.md` — full documentation including environment variables, companion tool alias table, core tools allowlist, companion discovery explanation, and guidance for extension authors
- Root `package.json` updated to register the extension

## Verified behavior

Tested interactively with `pi -e` against Anthropic OAuth (Sonnet). Debug log confirms:
- **Before:** 18 tools (4 core + 7 flat companion + 7 MCP aliases), system prompt contains `"pi itself"`
- **After:** 11 tools (4 core + 7 MCP aliases), all flat names removed, system prompt rewritten
- Zero flat companion names leaked to Anthropic API across all requests

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (123 tests, 39 in this package)
- [x] Interactive run with `PI_CLAUDE_CODE_USE_DEBUG_LOG` confirms before/after payload transformation
- [x] Pipe mode (`pi -p`) confirmed working
- [x] End-to-end tool invocation test with Anthropic OAuth (e.g. ask model to use exa search)