### PR TITLE
fix: narrow pi-claude-code-use Anthropic prompt rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5627,7 +5627,7 @@
     },
     "packages/pi-claude-code-use": {
       "name": "@benvargas/pi-claude-code-use",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.5",

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -8,7 +8,11 @@ It does not register a new provider or replace Pi's Anthropic request transport.
 
 When Pi is using Anthropic OAuth, this extension intercepts outbound API requests via the `before_provider_request` hook and:
 
-- **System prompt rewrite** -- replaces `pi itself` with `the cli itself` in system prompt text. Preserves Pi's original `system[]` structure, `cache_control` metadata, and non-text blocks.
+- **System prompt rewrite** -- rewrites a small set of Pi-identifying prompt phrases in system prompt text:
+  - `pi itself` → `the cli itself`
+  - `pi .md files` → `cli .md files`
+  - `pi packages` → `cli packages`
+  Preserves Pi's original `system[]` structure, `cache_control` metadata, and non-text blocks.
 - **Tool filtering** -- passes through core Claude Code tools, Anthropic-native typed tools (e.g. `web_search`), and any tool prefixed with `mcp__`. Unknown flat-named tools are filtered out.
 - **Companion tool remapping** -- renames known companion extension tools from their flat names to MCP-style aliases (e.g. `web_search_exa` becomes `mcp__exa__web_search`). Duplicate flat entries are removed after remapping.
 - **tool_choice remapping** -- if `tool_choice` references a flat companion name that was remapped, the reference is updated to the MCP alias. If it references a tool that was filtered out, `tool_choice` is removed from the payload.

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -166,6 +166,19 @@ describe("pi-claude-code-use", () => {
 		expect(_test.rewritePromptText("pi itself and pi itself again")).toBe("the cli itself and the cli itself again");
 	});
 
+	it("rewrites the additional Pi prompt tokens that trigger Anthropic filtering", () => {
+		const prompt =
+			"Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):\n" +
+			"- When asked about: custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)\n" +
+			"- Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)";
+
+		expect(_test.rewritePromptText(prompt)).toBe(
+			"Pi documentation (read only when the user asks about the cli itself, its SDK, extensions, themes, skills, or TUI):\n" +
+				"- When asked about: custom providers (docs/custom-provider.md), adding models (docs/models.md), cli packages (docs/packages.md)\n" +
+				"- Always read cli .md files completely and follow links to related docs (e.g., tui.md for TUI API details)",
+		);
+	});
+
 	// ----------------------------------------------------------------
 	// Tool filtering and MCP alias remapping (PRD §1.2)
 	// ----------------------------------------------------------------

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -113,7 +113,10 @@ function lower(name: string | undefined): string {
 // ============================================================================
 
 function rewritePromptText(text: string): string {
-	return text.replaceAll("pi itself", "the cli itself");
+	return text
+		.replaceAll("pi itself", "the cli itself")
+		.replaceAll("pi .md files", "cli .md files")
+		.replaceAll("pi packages", "cli packages");
 }
 
 function rewriteSystemField(system: unknown): unknown {

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-claude-code-use",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary
Adjust the minimal Anthropic OAuth prompt rewrite in `pi-claude-code-use` and bump the package version to `1.0.1`.

## Validation
- `npm run test -- --run packages/pi-claude-code-use/__tests__/index.test.ts`
- `npm run typecheck`
- Verified the Anthropic OAuth repro path from the repo cwd
