### PR TITLE
[codex] Add pi-openai-verbosity extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pi packages can include extensions, skills, prompt templates, and themes. See th
 | [@benvargas/pi-ancestor-discovery](./packages/pi-ancestor-discovery/) | Extension | Ancestor discovery for skills, prompts, themes |
 | [@benvargas/pi-cut-stack](./packages/pi-cut-stack/) | Extension | Cut-stack editor shortcuts |
 | [@benvargas/pi-openai-fast](./packages/pi-openai-fast/) | Extension | `/fast` toggle for OpenAI priority service tier on supported GPT-5.4 models |
+| [@benvargas/pi-openai-verbosity](./packages/pi-openai-verbosity/) | Extension | Config-backed OpenAI Codex text verbosity rewrites |
 | [@benvargas/pi-claude-code-use](./packages/pi-claude-code-use/) | Extension | Anthropic/Claude OAuth compatibility patching |
 
 Each package has its own README with setup instructions, usage, and configuration details.
@@ -56,6 +57,7 @@ pi install npm:@benvargas/pi-firecrawl
 pi install npm:@benvargas/pi-ancestor-discovery
 pi install npm:@benvargas/pi-cut-stack
 pi install npm:@benvargas/pi-openai-fast
+pi install npm:@benvargas/pi-openai-verbosity
 pi install npm:@benvargas/pi-claude-code-use
 ```
 
@@ -86,6 +88,7 @@ pi remove npm:@benvargas/pi-firecrawl
 pi remove npm:@benvargas/pi-ancestor-discovery
 pi remove npm:@benvargas/pi-cut-stack
 pi remove npm:@benvargas/pi-openai-fast
+pi remove npm:@benvargas/pi-openai-verbosity
 pi remove npm:@benvargas/pi-claude-code-use
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,6 +935,10 @@
       "resolved": "packages/pi-openai-fast",
       "link": true
     },
+    "node_modules/@benvargas/pi-openai-verbosity": {
+      "resolved": "packages/pi-openai-verbosity",
+      "link": true
+    },
     "node_modules/@benvargas/pi-synthetic-provider": {
       "resolved": "packages/pi-synthetic-provider",
       "link": true
@@ -5675,9 +5679,17 @@
         "@mariozechner/pi-coding-agent": ">=0.57.0"
       }
     },
+    "packages/pi-openai-verbosity": {
+      "name": "@benvargas/pi-openai-verbosity",
+      "version": "1.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": ">=0.57.0"
+      }
+    },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": "*"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
       "./packages/pi-ancestor-discovery/extensions/index.ts",
       "./packages/pi-cut-stack/extensions/index.ts",
       "./packages/pi-openai-fast/extensions/index.ts",
+      "./packages/pi-openai-verbosity/extensions/index.ts",
       "./packages/pi-claude-code-use/extensions/index.ts"
     ]
   },

--- a/packages/pi-openai-verbosity/LICENSE
+++ b/packages/pi-openai-verbosity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ben Vargas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-openai-verbosity/README.md
+++ b/packages/pi-openai-verbosity/README.md
@@ -1,0 +1,112 @@
+# @benvargas/pi-openai-verbosity
+
+Config-backed text verbosity rewrites for pi provider requests.
+
+This extension uses pi's `before_provider_request` hook to set provider request verbosity when the current model matches a configured `provider/model-id` key. It initially supports OpenAI Codex provider models that Codex marks as verbosity-capable.
+
+Requires pi `0.57.0` or newer.
+
+## Install
+
+```bash
+pi install npm:@benvargas/pi-openai-verbosity
+```
+
+Or try without installing:
+
+```bash
+pi -e npm:@benvargas/pi-openai-verbosity
+```
+
+## Usage
+
+By default, the extension sets `text.verbosity` to `low` for supported `openai-codex/*` models.
+
+```bash
+pi -e npm:@benvargas/pi-openai-verbosity --model openai-codex/gpt-5.5
+```
+
+Use `/openai-verbosity status` to report the configured rewrite for the current model. The command also reloads the config file.
+
+## Config
+
+Config files follow the same project-over-global pattern as the other packages:
+
+- Project: `<repo>/.pi/extensions/pi-openai-verbosity.json`
+- Global: `~/.pi/agent/extensions/pi-openai-verbosity.json`
+
+If neither exists, the extension writes a default global config on first run.
+
+Default config:
+
+```json
+{
+  "models": {
+    "openai-codex/gpt-5.4": "low",
+    "openai-codex/gpt-5.5": "low",
+    "openai-codex/gpt-5.4-mini": "low",
+    "openai-codex/gpt-5.3-codex": "low",
+    "openai-codex/gpt-5.3-codex-spark": "low",
+    "openai-codex/gpt-5.2": "low",
+    "openai-codex/codex-auto-review": "low"
+  }
+}
+```
+
+Settings:
+
+- `models`: object mapping supported `provider/model-id` strings to `low`, `medium`, or `high`. Currently, supported keys must use the `openai-codex` provider.
+
+Project config overrides global config per model key. Any model not listed is left unchanged.
+
+The default model list comes from `~/.codex/models_cache.json` entries with `support_verbosity: true`, mapped to pi's `openai-codex/<slug>` provider keys.
+
+Example:
+
+```json
+{
+  "models": {
+    "openai-codex/gpt-5.5": "low",
+    "openai-codex/gpt-5.4": "low"
+  }
+}
+```
+
+## Environment Variables
+
+Pi does not currently expose a simple CLI flag to print the final provider request body. To verify this extension is matching and rewriting a request, set `PI_OPENAI_VERBOSITY_DEBUG_LOG` to a JSONL file path.
+
+| Variable | Description |
+|---|---|
+| `PI_OPENAI_VERBOSITY_DEBUG_LOG` | Set to a file path to enable debug logging. Matching requests write `"before"` and `"after"` JSON entries with the full provider payload. Non-matching requests write one `"skipped"` entry. |
+
+```bash
+PI_OPENAI_VERBOSITY_DEBUG_LOG=/tmp/pi-openai-verbosity.jsonl \
+  pi -e npm:@benvargas/pi-openai-verbosity \
+  --model openai-codex/gpt-5.5 \
+  -p "Reply in one short sentence."
+```
+
+Then inspect the last entries:
+
+```bash
+tail -n 5 /tmp/pi-openai-verbosity.jsonl | jq .
+```
+
+These entries include prompts, messages, tools, and the rest of the provider payload, so keep the file local and delete it when you are done debugging.
+
+## Notes
+
+- The extension only changes the outgoing request payload.
+- Existing `text` fields are preserved, and only `text.verbosity` is replaced.
+- Non-matching models are ignored.
+
+## Uninstall
+
+```bash
+pi remove npm:@benvargas/pi-openai-verbosity
+```
+
+## License
+
+MIT

--- a/packages/pi-openai-verbosity/__tests__/helpers.test.ts
+++ b/packages/pi-openai-verbosity/__tests__/helpers.test.ts
@@ -1,0 +1,117 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { _test } from "../extensions/index.js";
+
+function createContext(model: ExtensionContext["model"]): ExtensionContext {
+	return {
+		model,
+	} as unknown as ExtensionContext;
+}
+
+function createTempConfigPaths(): { cwd: string; homeDir: string; cleanup: () => void } {
+	const root = mkdtempSync(join(tmpdir(), "pi-openai-verbosity-"));
+	const cwd = join(root, "workspace");
+	const homeDir = join(root, "home");
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(homeDir, { recursive: true });
+	return {
+		cwd,
+		homeDir,
+		cleanup: () => {
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}
+
+describe("pi-openai-verbosity helpers", () => {
+	it("normalizes model keys and verbosity maps", () => {
+		expect(_test.normalizeModelKey(" openai-codex/gpt-5.5 ")).toBe("openai-codex/gpt-5.5");
+		expect(_test.normalizeModelKey("gpt-5.5")).toBeUndefined();
+		expect(_test.normalizeModelKey("openai/gpt-5.5")).toBeUndefined();
+		expect(
+			_test.normalizeModelVerbosityMap({ " openai-codex/gpt-5.5 ": "low", "openai-codex/gpt-5.4": "loud" }),
+		).toEqual({
+			"openai-codex/gpt-5.5": "low",
+		});
+		expect(_test.normalizeModelVerbosityMap([])).toBeUndefined();
+	});
+
+	it("writes a default config and resolves project overrides", () => {
+		const { cwd, homeDir, cleanup } = createTempConfigPaths();
+		try {
+			const defaultConfig = _test.resolveVerbosityConfig(cwd, homeDir);
+			expect(defaultConfig.models).toEqual(_test.DEFAULT_MODEL_VERBOSITY);
+			expect(defaultConfig.models).toMatchObject({
+				"openai-codex/gpt-5.4": "low",
+				"openai-codex/gpt-5.5": "low",
+				"openai-codex/gpt-5.4-mini": "low",
+				"openai-codex/gpt-5.3-codex": "low",
+				"openai-codex/gpt-5.3-codex-spark": "low",
+				"openai-codex/gpt-5.2": "low",
+				"openai-codex/codex-auto-review": "low",
+			});
+
+			const { projectConfigPath, globalConfigPath } = _test.getConfigPaths(cwd, homeDir);
+			expect(_test.readConfigFile(globalConfigPath)).toEqual(_test.DEFAULT_CONFIG_FILE);
+
+			mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+			writeFileSync(
+				projectConfigPath,
+				`${JSON.stringify({ models: { "openai-codex/gpt-5.5": "medium", "openai-codex/gpt-5.4": "low" } }, null, 2)}\n`,
+				"utf-8",
+			);
+
+			const overriddenConfig = _test.resolveVerbosityConfig(cwd, homeDir);
+			expect(overriddenConfig.configPath).toBe(projectConfigPath);
+			expect(overriddenConfig.models).toMatchObject({
+				"openai-codex/gpt-5.5": "medium",
+				"openai-codex/gpt-5.4": "low",
+			});
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("describes state and applies text verbosity without dropping text fields", () => {
+		const config = {
+			configPath: "/tmp/pi-openai-verbosity.json",
+			models: { "openai-codex/gpt-5.5": "low" as const },
+		};
+		expect(
+			_test.describeCurrentState(
+				createContext({ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"]),
+				config,
+			),
+		).toBe("OpenAI verbosity sets text.verbosity=low for openai-codex/gpt-5.5.");
+		expect(_test.describeCurrentState(createContext(undefined), config)).toContain("none");
+		expect(
+			_test.applyTextVerbosity({ input: "hello", text: { format: { type: "text" }, verbosity: "medium" } }, "low"),
+		).toEqual({
+			input: "hello",
+			text: {
+				format: { type: "text" },
+				verbosity: "low",
+			},
+		});
+		expect(_test.applyTextVerbosity("not-an-object", "low")).toBe("not-an-object");
+	});
+
+	it("writes JSONL debug entries with timestamps", () => {
+		const { cwd, cleanup } = createTempConfigPaths();
+		try {
+			const debugLogPath = join(cwd, "debug", "verbosity.jsonl");
+			_test.writeDebugLog({ model: "openai-codex/gpt-5.5", matched: true }, debugLogPath);
+
+			const line = readFileSync(debugLogPath, "utf-8").trim();
+			const entry = JSON.parse(line) as Record<string, unknown>;
+			expect(entry.timestamp).toEqual(expect.any(String));
+			expect(entry.model).toBe("openai-codex/gpt-5.5");
+			expect(entry.matched).toBe(true);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/pi-openai-verbosity/__tests__/index.test.ts
+++ b/packages/pi-openai-verbosity/__tests__/index.test.ts
@@ -1,0 +1,338 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	BeforeProviderRequestEvent,
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	RegisteredCommand,
+} from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import piOpenAIVerbosity, { _test } from "../extensions/index.js";
+
+type RegisteredHandlers = Map<string, (event: unknown, ctx: ExtensionContext) => unknown>;
+
+type MockPi = {
+	commands: Map<string, Omit<RegisteredCommand, "name">>;
+	handlers: RegisteredHandlers;
+	registerCommand: ReturnType<typeof vi.fn>;
+	on: ReturnType<typeof vi.fn>;
+};
+
+type MockUi = {
+	notify: ReturnType<typeof vi.fn>;
+};
+
+function createTempWorkspace(): { cwd: string; homeDir: string; cleanup: () => void } {
+	const root = mkdtempSync(join(tmpdir(), "pi-openai-verbosity-"));
+	const cwd = join(root, "workspace");
+	const homeDir = join(root, "home");
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(homeDir, { recursive: true });
+	return {
+		cwd,
+		homeDir,
+		cleanup: () => {
+			vi.unstubAllEnvs();
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}
+
+function createMockPi(): MockPi {
+	const commands = new Map<string, Omit<RegisteredCommand, "name">>();
+	const handlers: RegisteredHandlers = new Map();
+
+	return {
+		commands,
+		handlers,
+		registerCommand: vi.fn((name: string, options: Omit<RegisteredCommand, "name">) => {
+			commands.set(name, options);
+		}),
+		on: vi.fn((event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
+			handlers.set(event, handler);
+		}),
+	};
+}
+
+function createMockContext(
+	model: ExtensionContext["model"],
+	cwd: string = process.cwd(),
+): { ctx: ExtensionCommandContext; ui: MockUi } {
+	const ui: MockUi = {
+		notify: vi.fn(),
+	};
+
+	const ctx = {
+		hasUI: true,
+		cwd,
+		sessionManager: {
+			getBranch: () => [],
+		},
+		modelRegistry: {},
+		model,
+		ui,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+		waitForIdle: async () => undefined,
+		newSession: async () => ({ cancelled: false }),
+		fork: async () => ({ cancelled: false }),
+		navigateTree: async () => ({ cancelled: false }),
+		switchSession: async () => ({ cancelled: false }),
+		reload: async () => undefined,
+	} as unknown as ExtensionCommandContext;
+
+	return { ctx, ui };
+}
+
+function getRegisteredCommand(mockPi: MockPi, name: string): Omit<RegisteredCommand, "name"> {
+	const command = mockPi.commands.get(name);
+	expect(command).toBeDefined();
+	if (!command) {
+		throw new Error(`Missing command: ${name}`);
+	}
+	return command;
+}
+
+function getRegisteredHandler(mockPi: MockPi, eventName: string): (event: unknown, ctx: ExtensionContext) => unknown {
+	const handler = mockPi.handlers.get(eventName);
+	expect(handler).toBeDefined();
+	if (!handler) {
+		throw new Error(`Missing handler: ${eventName}`);
+	}
+	return handler;
+}
+
+describe("pi-openai-verbosity", () => {
+	it("registers the openai-verbosity command and provider request hook", () => {
+		const mockPi = createMockPi();
+		piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+
+		expect(mockPi.commands.has("openai-verbosity")).toBe(true);
+		expect(mockPi.handlers.has("before_provider_request")).toBe(true);
+	});
+
+	it("injects low text verbosity for the default configured model", () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+			const { ctx } = createMockContext({ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"], cwd);
+
+			const payload = beforeProviderRequest(
+				{
+					type: "before_provider_request",
+					payload: { input: "hello", text: { verbosity: "medium" } },
+				} as BeforeProviderRequestEvent,
+				ctx,
+			);
+			expect(payload).toEqual({ input: "hello", text: { verbosity: "low" } });
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("writes before and after debug entries when verbosity is applied", () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+			const debugLogPath = join(cwd, "debug", "verbosity.jsonl");
+			vi.stubEnv("PI_OPENAI_VERBOSITY_DEBUG_LOG", debugLogPath);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+			const { ctx } = createMockContext({ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"], cwd);
+
+			beforeProviderRequest(
+				{
+					type: "before_provider_request",
+					payload: { input: "hello", text: { verbosity: "medium" } },
+				} as BeforeProviderRequestEvent,
+				ctx,
+			);
+
+			const entries = readFileSync(debugLogPath, "utf-8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(entries).toHaveLength(2);
+			expect(entries[0]).toMatchObject({
+				stage: "before",
+				model: "openai-codex/gpt-5.5",
+				matched: true,
+				configuredVerbosity: "low",
+				beforeTextVerbosity: "medium",
+				payload: { input: "hello", text: { verbosity: "medium" } },
+			});
+			expect(entries[1]).toMatchObject({
+				stage: "after",
+				model: "openai-codex/gpt-5.5",
+				matched: true,
+				configuredVerbosity: "low",
+				beforeTextVerbosity: "medium",
+				afterTextVerbosity: "low",
+				payload: { input: "hello", text: { verbosity: "low" } },
+			});
+			expect(entries[0]?.timestamp).toEqual(expect.any(String));
+			expect(entries[1]?.timestamp).toEqual(expect.any(String));
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("writes a debug entry when a model is not configured", () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+			const debugLogPath = join(cwd, "debug", "verbosity.jsonl");
+			vi.stubEnv("PI_OPENAI_VERBOSITY_DEBUG_LOG", debugLogPath);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+			const { ctx } = createMockContext({ provider: "openai-codex", id: "gpt-5.1" } as ExtensionContext["model"], cwd);
+
+			beforeProviderRequest(
+				{
+					type: "before_provider_request",
+					payload: { input: "hello", text: { verbosity: "medium" } },
+				} as BeforeProviderRequestEvent,
+				ctx,
+			);
+
+			const entry = JSON.parse(readFileSync(debugLogPath, "utf-8").trim()) as Record<string, unknown>;
+			expect(entry).toMatchObject({
+				stage: "skipped",
+				model: "openai-codex/gpt-5.1",
+				matched: false,
+				beforeTextVerbosity: "medium",
+				payload: { input: "hello", text: { verbosity: "medium" } },
+			});
+			expect(entry.timestamp).toEqual(expect.any(String));
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("injects low text verbosity for every default configured model", () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+
+			for (const modelKey of Object.keys(_test.DEFAULT_MODEL_VERBOSITY)) {
+				const id = modelKey.slice("openai-codex/".length);
+				const { ctx } = createMockContext({ provider: "openai-codex", id } as ExtensionContext["model"], cwd);
+				expect(
+					beforeProviderRequest(
+						{ type: "before_provider_request", payload: { input: "hello" } } as BeforeProviderRequestEvent,
+						ctx,
+					),
+				).toEqual({ input: "hello", text: { verbosity: "low" } });
+			}
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("skips payload changes for unconfigured models", () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+			const { ctx } = createMockContext({ provider: "openai-codex", id: "gpt-5.1" } as ExtensionContext["model"], cwd);
+
+			expect(
+				beforeProviderRequest(
+					{ type: "before_provider_request", payload: { input: "hello" } } as BeforeProviderRequestEvent,
+					ctx,
+				),
+			).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("uses configured verbosity per model and refreshes config on /openai-verbosity status", async () => {
+		const { cwd, homeDir, cleanup } = createTempWorkspace();
+		try {
+			vi.stubEnv("HOME", homeDir);
+			const { globalConfigPath } = _test.getConfigPaths(cwd, homeDir);
+			mkdirSync(join(homeDir, ".pi", "agent", "extensions"), { recursive: true });
+			writeFileSync(
+				globalConfigPath,
+				`${JSON.stringify({ models: { "openai-codex/gpt-5.5": "high" } }, null, 2)}\n`,
+				"utf-8",
+			);
+
+			const mockPi = createMockPi();
+			piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+			const command = getRegisteredCommand(mockPi, "openai-verbosity");
+			const beforeProviderRequest = getRegisteredHandler(mockPi, "before_provider_request");
+			const { ctx, ui } = createMockContext(
+				{ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"],
+				cwd,
+			);
+
+			expect(
+				beforeProviderRequest(
+					{ type: "before_provider_request", payload: { input: "hello" } } as BeforeProviderRequestEvent,
+					ctx,
+				),
+			).toEqual({ input: "hello", text: { verbosity: "high" } });
+
+			writeFileSync(
+				globalConfigPath,
+				`${JSON.stringify({ models: { "openai-codex/gpt-5.5": "low" } }, null, 2)}\n`,
+				"utf-8",
+			);
+			expect(
+				beforeProviderRequest(
+					{ type: "before_provider_request", payload: { input: "hello" } } as BeforeProviderRequestEvent,
+					ctx,
+				),
+			).toEqual({ input: "hello", text: { verbosity: "high" } });
+
+			await command.handler("status", ctx);
+			expect(ui.notify).toHaveBeenLastCalledWith(
+				"OpenAI verbosity sets text.verbosity=low for openai-codex/gpt-5.5.",
+				"info",
+			);
+			expect(
+				beforeProviderRequest(
+					{ type: "before_provider_request", payload: { input: "hello" } } as BeforeProviderRequestEvent,
+					ctx,
+				),
+			).toEqual({ input: "hello", text: { verbosity: "low" } });
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports usage for invalid command arguments", async () => {
+		const mockPi = createMockPi();
+		piOpenAIVerbosity(mockPi as unknown as ExtensionAPI);
+
+		const command = getRegisteredCommand(mockPi, "openai-verbosity");
+		const { ctx, ui } = createMockContext({ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"]);
+		await command.handler("loud", ctx);
+
+		expect(ui.notify).toHaveBeenCalledWith("Usage: /openai-verbosity [status]", "error");
+	});
+});

--- a/packages/pi-openai-verbosity/extensions/index.ts
+++ b/packages/pi-openai-verbosity/extensions/index.ts
@@ -1,0 +1,323 @@
+/**
+ * OpenAI verbosity for pi.
+ *
+ * Sets OpenAI Responses `text.verbosity` for configured models via the
+ * `before_provider_request` hook. Config precedence is project
+ * `.pi/extensions/pi-openai-verbosity.json` over global
+ * `~/.pi/agent/extensions/pi-openai-verbosity.json`.
+ */
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const VERBOSITY_COMMAND = "openai-verbosity";
+const VERBOSITY_CONFIG_BASENAME = "pi-openai-verbosity.json";
+const VERBOSITY_COMMAND_ARGS = ["status"] as const;
+const DEBUG_LOG_ENV = "PI_OPENAI_VERBOSITY_DEBUG_LOG";
+const SUPPORTED_PROVIDERS = ["openai-codex"] as const;
+const DEFAULT_MODEL_VERBOSITY = {
+	"openai-codex/gpt-5.4": "low",
+	"openai-codex/gpt-5.5": "low",
+	"openai-codex/gpt-5.4-mini": "low",
+	"openai-codex/gpt-5.3-codex": "low",
+	"openai-codex/gpt-5.3-codex-spark": "low",
+	"openai-codex/gpt-5.2": "low",
+	"openai-codex/codex-auto-review": "low",
+} as const;
+
+type TextVerbosity = "low" | "medium" | "high";
+
+interface VerbosityConfigFile {
+	models?: Record<string, TextVerbosity>;
+}
+
+interface ResolvedVerbosityConfig {
+	configPath: string;
+	models: Record<string, TextVerbosity>;
+}
+
+type VerbosityPayload = {
+	text?: unknown;
+	[key: string]: unknown;
+};
+
+const DEFAULT_CONFIG_FILE: VerbosityConfigFile = {
+	models: { ...DEFAULT_MODEL_VERBOSITY },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTextVerbosity(value: unknown): value is TextVerbosity {
+	return value === "low" || value === "medium" || value === "high";
+}
+
+function normalizeModelKey(value: string): string | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	const slashIndex = trimmed.indexOf("/");
+	if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+		return undefined;
+	}
+	const provider = trimmed.slice(0, slashIndex).trim();
+	const id = trimmed.slice(slashIndex + 1).trim();
+	if (!provider || !id) {
+		return undefined;
+	}
+	if (!SUPPORTED_PROVIDERS.includes(provider as (typeof SUPPORTED_PROVIDERS)[number])) {
+		return undefined;
+	}
+	return `${provider}/${id}`;
+}
+
+function normalizeModelVerbosityMap(value: unknown): Record<string, TextVerbosity> | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!isRecord(value)) {
+		return undefined;
+	}
+
+	const normalized: Record<string, TextVerbosity> = {};
+	for (const [rawKey, rawVerbosity] of Object.entries(value)) {
+		const key = normalizeModelKey(rawKey);
+		if (!key || !isTextVerbosity(rawVerbosity)) {
+			continue;
+		}
+		normalized[key] = rawVerbosity;
+	}
+	return normalized;
+}
+
+function getConfigCwd(ctx: ExtensionContext): string {
+	return ctx.cwd || process.cwd();
+}
+
+function getConfigPaths(
+	cwd: string,
+	homeDir: string = homedir(),
+): {
+	projectConfigPath: string;
+	globalConfigPath: string;
+} {
+	return {
+		projectConfigPath: join(cwd, ".pi", "extensions", VERBOSITY_CONFIG_BASENAME),
+		globalConfigPath: join(homeDir, ".pi", "agent", "extensions", VERBOSITY_CONFIG_BASENAME),
+	};
+}
+
+function readConfigFile(filePath: string): VerbosityConfigFile | null {
+	if (!existsSync(filePath)) {
+		return null;
+	}
+	try {
+		const raw = readFileSync(filePath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (!isRecord(parsed)) {
+			return {};
+		}
+		const models = normalizeModelVerbosityMap(parsed.models);
+		return models === undefined ? {} : { models };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-openai-verbosity] Failed to read ${filePath}: ${message}`);
+		return null;
+	}
+}
+
+function writeConfigFile(filePath: string, config: VerbosityConfigFile): void {
+	try {
+		mkdirSync(dirname(filePath), { recursive: true });
+		writeFileSync(filePath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-openai-verbosity] Failed to write ${filePath}: ${message}`);
+	}
+}
+
+function ensureDefaultConfigFile(projectConfigPath: string, globalConfigPath: string): void {
+	if (existsSync(projectConfigPath) || existsSync(globalConfigPath)) {
+		return;
+	}
+	writeConfigFile(globalConfigPath, DEFAULT_CONFIG_FILE);
+}
+
+function resolveVerbosityConfig(cwd: string, homeDir: string = homedir()): ResolvedVerbosityConfig {
+	const { projectConfigPath, globalConfigPath } = getConfigPaths(cwd, homeDir);
+	ensureDefaultConfigFile(projectConfigPath, globalConfigPath);
+
+	const globalConfig = readConfigFile(globalConfigPath) ?? {};
+	const projectConfig = readConfigFile(projectConfigPath) ?? {};
+	const selectedConfigPath = existsSync(projectConfigPath) ? projectConfigPath : globalConfigPath;
+
+	return {
+		configPath: selectedConfigPath,
+		models: {
+			...DEFAULT_MODEL_VERBOSITY,
+			...(globalConfig.models ?? {}),
+			...(projectConfig.models ?? {}),
+		},
+	};
+}
+
+function getCurrentModelKey(model: ExtensionContext["model"]): string | undefined {
+	if (!model) {
+		return undefined;
+	}
+	return `${model.provider}/${model.id}`;
+}
+
+function getVerbosityForModel(
+	model: ExtensionContext["model"],
+	models: Record<string, TextVerbosity>,
+): TextVerbosity | undefined {
+	const modelKey = getCurrentModelKey(model);
+	return modelKey ? models[modelKey] : undefined;
+}
+
+function describeConfiguredModels(models: Record<string, TextVerbosity>): string {
+	const entries = Object.entries(models);
+	if (entries.length === 0) {
+		return "none configured";
+	}
+	return entries.map(([model, verbosity]) => `${model}=${verbosity}`).join(", ");
+}
+
+function describeCurrentState(ctx: ExtensionContext, config: ResolvedVerbosityConfig): string {
+	const model = getCurrentModelKey(ctx.model) ?? "none";
+	const verbosity = getVerbosityForModel(ctx.model, config.models);
+	if (verbosity) {
+		return `OpenAI verbosity sets text.verbosity=${verbosity} for ${model}.`;
+	}
+	return `OpenAI verbosity has no setting configured for ${model}. Configured models: ${describeConfiguredModels(
+		config.models,
+	)}.`;
+}
+
+function applyTextVerbosity(payload: unknown, verbosity: TextVerbosity): unknown {
+	if (!isRecord(payload)) {
+		return payload;
+	}
+
+	const nextPayload: VerbosityPayload = { ...payload };
+	const text = isRecord(nextPayload.text) ? { ...nextPayload.text } : {};
+	text.verbosity = verbosity;
+	nextPayload.text = text;
+	return nextPayload;
+}
+
+function getPayloadTextVerbosity(payload: unknown): unknown {
+	if (!isRecord(payload) || !isRecord(payload.text)) {
+		return undefined;
+	}
+	return payload.text.verbosity;
+}
+
+function writeDebugLog(
+	entry: Record<string, unknown>,
+	debugLogPath: string | undefined = process.env[DEBUG_LOG_ENV],
+): void {
+	if (!debugLogPath) {
+		return;
+	}
+	try {
+		mkdirSync(dirname(debugLogPath), { recursive: true });
+		appendFileSync(debugLogPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...entry })}\n`, "utf-8");
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-openai-verbosity] Failed to write debug log ${debugLogPath}: ${message}`);
+	}
+}
+
+export default function piOpenAIVerbosity(pi: ExtensionAPI): void {
+	let cachedConfig: ResolvedVerbosityConfig | undefined;
+
+	function refreshConfig(ctx: ExtensionContext): ResolvedVerbosityConfig {
+		cachedConfig = resolveVerbosityConfig(getConfigCwd(ctx));
+		return cachedConfig;
+	}
+
+	function getConfig(ctx: ExtensionContext): ResolvedVerbosityConfig {
+		return cachedConfig ?? refreshConfig(ctx);
+	}
+
+	pi.registerCommand(VERBOSITY_COMMAND, {
+		description: "Report configured GPT text verbosity rewrites",
+		getArgumentCompletions: (prefix) => {
+			const items = VERBOSITY_COMMAND_ARGS.filter((value) => value.startsWith(prefix)).map((value) => ({
+				value,
+				label: value,
+			}));
+			return items.length > 0 ? items : null;
+		},
+		handler: async (args, ctx) => {
+			const command = args.trim().toLowerCase();
+			if (command.length > 0 && command !== "status") {
+				ctx.ui.notify("Usage: /openai-verbosity [status]", "error");
+				return;
+			}
+			ctx.ui.notify(describeCurrentState(ctx, refreshConfig(ctx)), "info");
+		},
+	});
+
+	pi.on("before_provider_request", (event, ctx) => {
+		const model = getCurrentModelKey(ctx.model) ?? null;
+		const beforeTextVerbosity = getPayloadTextVerbosity(event.payload);
+		const verbosity = getVerbosityForModel(ctx.model, getConfig(ctx).models);
+		if (!verbosity) {
+			writeDebugLog({
+				stage: "skipped",
+				model,
+				matched: false,
+				beforeTextVerbosity: beforeTextVerbosity ?? null,
+				payload: event.payload,
+			});
+			return;
+		}
+		writeDebugLog({
+			stage: "before",
+			model,
+			matched: true,
+			configuredVerbosity: verbosity,
+			beforeTextVerbosity: beforeTextVerbosity ?? null,
+			payload: event.payload,
+		});
+		const nextPayload = applyTextVerbosity(event.payload, verbosity);
+		writeDebugLog({
+			stage: "after",
+			model,
+			matched: true,
+			configuredVerbosity: verbosity,
+			beforeTextVerbosity: beforeTextVerbosity ?? null,
+			afterTextVerbosity: getPayloadTextVerbosity(nextPayload) ?? null,
+			payload: nextPayload,
+		});
+		return nextPayload;
+	});
+}
+
+export const _test = {
+	VERBOSITY_COMMAND,
+	VERBOSITY_CONFIG_BASENAME,
+	VERBOSITY_COMMAND_ARGS,
+	SUPPORTED_PROVIDERS,
+	DEFAULT_MODEL_VERBOSITY,
+	DEFAULT_CONFIG_FILE,
+	isTextVerbosity,
+	normalizeModelKey,
+	normalizeModelVerbosityMap,
+	getConfigPaths,
+	readConfigFile,
+	resolveVerbosityConfig,
+	getCurrentModelKey,
+	getVerbosityForModel,
+	describeConfiguredModels,
+	describeCurrentState,
+	applyTextVerbosity,
+	getPayloadTextVerbosity,
+	writeDebugLog,
+};

--- a/packages/pi-openai-verbosity/package.json
+++ b/packages/pi-openai-verbosity/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@benvargas/pi-openai-verbosity",
+  "version": "1.0.0",
+  "description": "OpenAI text verbosity rewrites for pi - Sets low verbosity for configured OpenAI Codex models",
+  "keywords": [
+    "pi",
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "openai",
+    "codex",
+    "gpt-5.5",
+    "verbosity",
+    "text-verbosity"
+  ],
+  "type": "module",
+  "files": [
+    "extensions/",
+    "README.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.57.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ben-vargas/pi-packages.git",
+    "directory": "packages/pi-openai-verbosity"
+  },
+  "author": "Ben Vargas",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ben-vargas/pi-packages/issues"
+  },
+  "homepage": "https://github.com/ben-vargas/pi-packages/tree/main/packages/pi-openai-verbosity#readme"
+}


### PR DESCRIPTION
## Summary
- Add @benvargas/pi-openai-verbosity, a Pi extension that rewrites OpenAI Codex provider request payloads with configured Responses API text.verbosity values.
- Seed default low verbosity mappings for Codex models that support verbosity, including gpt-5.5, matching Codex CLI's low default for supported models.
- Add project/global JSON config support, /openai-verbosity status, opt-in PI_OPENAI_VERBOSITY_DEBUG_LOG request inspection, package README docs, and focused Vitest coverage.

## Context
Pi's openai-codex provider can send text.verbosity, but normal coding-agent usage was defaulting to medium. This package uses before_provider_request so the behavior can be adjusted without patching Pi core.

## Validation
- npm run lint
- npm run typecheck
- npm run test
- Manual Pi smoke test with PI_OPENAI_VERBOSITY_DEBUG_LOG confirmed text.verbosity changed from medium to low for openai-codex/gpt-5.5.