### PR TITLE
[codex] feat(pi-openai-fast): support gpt-5.5 fast mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5673,7 +5673,7 @@
     },
     "packages/pi-openai-fast": {
       "name": "@benvargas/pi-openai-fast",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "peerDependencies": {
         "@mariozechner/pi-coding-agent": ">=0.57.0"

--- a/packages/pi-openai-fast/README.md
+++ b/packages/pi-openai-fast/README.md
@@ -51,7 +51,9 @@ Default config:
   "active": false,
   "supportedModels": [
     "openai/gpt-5.4",
-    "openai-codex/gpt-5.4"
+    "openai/gpt-5.5",
+    "openai-codex/gpt-5.4",
+    "openai-codex/gpt-5.5"
   ]
 }
 ```

--- a/packages/pi-openai-fast/__tests__/helpers.test.ts
+++ b/packages/pi-openai-fast/__tests__/helpers.test.ts
@@ -28,15 +28,31 @@ function createTempConfigPaths(): { cwd: string; homeDir: string; cleanup: () =>
 
 describe("pi-openai-fast helpers", () => {
 	it("parses supported model keys and recognizes supported fast models", () => {
-		const supportedModels = _test.parseSupportedModels(["openai/gpt-5.4", "openai-codex/gpt-5.4"]) ?? [];
+		const supportedModels =
+			_test.parseSupportedModels([
+				"openai/gpt-5.4",
+				"openai/gpt-5.5",
+				"openai-codex/gpt-5.4",
+				"openai-codex/gpt-5.5",
+			]) ?? [];
 		expect(_test.parseSupportedModelKey("openai/gpt-5.4")).toEqual({ provider: "openai", id: "gpt-5.4" });
+		expect(_test.parseSupportedModelKey("openai/gpt-5.5")).toEqual({ provider: "openai", id: "gpt-5.5" });
 		expect(_test.parseSupportedModelKey("invalid-model")).toBeUndefined();
 		expect(
 			_test.isFastSupportedModel({ provider: "openai", id: "gpt-5.4" } as ExtensionContext["model"], supportedModels),
 		).toBe(true);
 		expect(
+			_test.isFastSupportedModel({ provider: "openai", id: "gpt-5.5" } as ExtensionContext["model"], supportedModels),
+		).toBe(true);
+		expect(
 			_test.isFastSupportedModel(
 				{ provider: "openai-codex", id: "gpt-5.4" } as ExtensionContext["model"],
+				supportedModels,
+			),
+		).toBe(true);
+		expect(
+			_test.isFastSupportedModel(
+				{ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"],
 				supportedModels,
 			),
 		).toBe(true);
@@ -58,7 +74,9 @@ describe("pi-openai-fast helpers", () => {
 			expect(defaultConfig.active).toBe(false);
 			expect(defaultConfig.supportedModels).toEqual([
 				{ provider: "openai", id: "gpt-5.4" },
+				{ provider: "openai", id: "gpt-5.5" },
 				{ provider: "openai-codex", id: "gpt-5.4" },
+				{ provider: "openai-codex", id: "gpt-5.5" },
 			]);
 
 			const { projectConfigPath, globalConfigPath } = _test.getConfigPaths(cwd, homeDir);
@@ -85,6 +103,17 @@ describe("pi-openai-fast helpers", () => {
 		}
 	});
 
+	it("migrates legacy default supported models without changing custom supported models", () => {
+		expect(_test.migrateSupportedModelKeys(["openai/gpt-5.4", "openai-codex/gpt-5.4"])).toEqual([
+			"openai/gpt-5.4",
+			"openai/gpt-5.5",
+			"openai-codex/gpt-5.4",
+			"openai-codex/gpt-5.5",
+		]);
+		expect(_test.migrateSupportedModelKeys(["openai/gpt-5.4"])).toEqual(["openai/gpt-5.4"]);
+		expect(_test.migrateSupportedModelKeys(undefined)).toBeUndefined();
+	});
+
 	it("describes the current state and injects the priority service tier", () => {
 		const supportedModels = _test.parseSupportedModels(_test.DEFAULT_SUPPORTED_MODEL_KEYS) ?? [];
 		expect(_test.describeCurrentState(createContext(undefined), false, supportedModels)).toBe(
@@ -92,11 +121,11 @@ describe("pi-openai-fast helpers", () => {
 		);
 		expect(
 			_test.describeCurrentState(
-				createContext({ provider: "openai", id: "gpt-5.4" } as ExtensionContext["model"]),
+				createContext({ provider: "openai", id: "gpt-5.5" } as ExtensionContext["model"]),
 				true,
 				supportedModels,
 			),
-		).toBe("Fast mode is on for openai/gpt-5.4.");
+		).toBe("Fast mode is on for openai/gpt-5.5.");
 		expect(
 			_test.describeCurrentState(
 				createContext({ provider: "anthropic", id: "claude-sonnet-4" } as ExtensionContext["model"]),

--- a/packages/pi-openai-fast/__tests__/index.test.ts
+++ b/packages/pi-openai-fast/__tests__/index.test.ts
@@ -179,7 +179,7 @@ describe("pi-openai-fast", () => {
 			expect(JSON.parse(readFileSync(globalConfigPath, "utf-8"))).toEqual({
 				persistState: true,
 				active: true,
-				supportedModels: ["openai/gpt-5.4", "openai-codex/gpt-5.4"],
+				supportedModels: ["openai/gpt-5.4", "openai/gpt-5.5", "openai-codex/gpt-5.4", "openai-codex/gpt-5.5"],
 			});
 		} finally {
 			cleanup();
@@ -208,7 +208,7 @@ describe("pi-openai-fast", () => {
 			await command.handler("on", ctx);
 
 			expect(ui.notify).toHaveBeenCalledWith(
-				"Fast mode is on, but anthropic/claude-sonnet-4 does not support it. Supported models: openai/gpt-5.4, openai-codex/gpt-5.4.",
+				"Fast mode is on, but anthropic/claude-sonnet-4 does not support it. Supported models: openai/gpt-5.4, openai/gpt-5.5, openai-codex/gpt-5.4, openai-codex/gpt-5.5.",
 				"info",
 			);
 

--- a/packages/pi-openai-fast/extensions/index.ts
+++ b/packages/pi-openai-fast/extensions/index.ts
@@ -20,7 +20,13 @@ const FAST_FLAG = "fast";
 const FAST_CONFIG_BASENAME = "pi-openai-fast.json";
 const FAST_COMMAND_ARGS = ["on", "off", "status"] as const;
 const FAST_SERVICE_TIER = "priority";
-const DEFAULT_SUPPORTED_MODEL_KEYS = ["openai/gpt-5.4", "openai-codex/gpt-5.4"] as const;
+const DEFAULT_SUPPORTED_MODEL_KEYS = [
+	"openai/gpt-5.4",
+	"openai/gpt-5.5",
+	"openai-codex/gpt-5.4",
+	"openai-codex/gpt-5.5",
+] as const;
+const LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS = ["openai/gpt-5.4", "openai-codex/gpt-5.4"] as const;
 
 interface FastModeState {
 	active: boolean;
@@ -132,6 +138,20 @@ function parseSupportedModels(value: unknown): FastSupportedModel[] | undefined 
 	return models;
 }
 
+function sameModelKeys(left: readonly string[] | undefined, right: readonly string[]): boolean {
+	if (!left || left.length !== right.length) {
+		return false;
+	}
+	return left.every((value, index) => value === right[index]);
+}
+
+function migrateSupportedModelKeys(value: string[] | undefined): string[] | undefined {
+	if (sameModelKeys(value, LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS)) {
+		return [...DEFAULT_SUPPORTED_MODEL_KEYS];
+	}
+	return value;
+}
+
 function readConfigFile(filePath: string): FastConfigFile | null {
 	if (!existsSync(filePath)) {
 		return null;
@@ -187,7 +207,8 @@ function resolveFastConfig(cwd: string, homeDir: string = homedir()): ResolvedFa
 	const selectedConfigPath = existsSync(projectConfigPath) ? projectConfigPath : globalConfigPath;
 	const merged = { ...globalConfig, ...projectConfig };
 	const supportedModels =
-		parseSupportedModels(merged.supportedModels) ?? parseSupportedModels(DEFAULT_SUPPORTED_MODEL_KEYS);
+		parseSupportedModels(migrateSupportedModelKeys(merged.supportedModels)) ??
+		parseSupportedModels(DEFAULT_SUPPORTED_MODEL_KEYS);
 
 	return {
 		configPath: selectedConfigPath,
@@ -379,10 +400,12 @@ export const _test = {
 	FAST_COMMAND_ARGS,
 	FAST_SERVICE_TIER,
 	DEFAULT_SUPPORTED_MODEL_KEYS,
+	LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS,
 	DEFAULT_CONFIG_FILE,
 	getConfigPaths,
 	parseSupportedModelKey,
 	parseSupportedModels,
+	migrateSupportedModelKeys,
 	readConfigFile,
 	resolveFastConfig,
 	isFastSupportedModel,

--- a/packages/pi-openai-fast/package.json
+++ b/packages/pi-openai-fast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@benvargas/pi-openai-fast",
-  "version": "1.0.2",
-  "description": "OpenAI fast mode toggle for pi - Enables priority service tier on supported GPT-5.4 models",
+  "version": "1.0.3",
+  "description": "OpenAI fast mode toggle for pi - Enables priority service tier on supported GPT-5 models",
   "keywords": [
     "pi",
     "pi-package",
@@ -10,6 +10,7 @@
     "openai",
     "codex",
     "gpt-5.4",
+    "gpt-5.5",
     "fast",
     "priority",
     "service-tier"


### PR DESCRIPTION
## Summary
- add openai/gpt-5.5 and openai-codex/gpt-5.5 to pi-openai-fast default supported models
- migrate the legacy generated default supportedModels list in-memory so existing default configs pick up gpt-5.5
- bump @benvargas/pi-openai-fast to 1.0.3 and update docs/tests

## Validation
- npm run test -- --run packages/pi-openai-fast
- npm run typecheck
- npm run lint -- packages/pi-openai-fast