### PR TITLE
feat(pi-claude-code-use): user-defined tool aliases via pi-claude-code-use.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5502,7 +5502,7 @@
     },
     "packages/pi-claude-code-use": {
       "name": "@benvargas/pi-claude-code-use",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.5"

--- a/packages/pi-claude-code-use/CHANGELOG.md
+++ b/packages/pi-claude-code-use/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.2] - 2026-05-02
+
+### Added
+- Added user-defined `toolAliases` config so flat-named tools from other extensions can be exposed under MCP-style aliases.
+- Documented global and project-level alias configuration for custom extension tools.

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -86,10 +86,13 @@ To register MCP-style aliases for flat-named tools from other installed extensio
 ```json
 {
   "toolAliases": [
-    ["subagent", "mcp__extension__subagent"]
+    ["subagent", "mcp__subagent__run"],
+    ["linear_search", "mcp__linear__search"]
   ]
 }
 ```
+
+Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; choose an MCP alias in the form `mcp__<namespace>__<tool>`.
 
 The project file replaces the global file as a whole. Set `"toolAliases": []` in the project file to disable inherited globals.
 

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -79,6 +79,20 @@ The extension identifies companion tools by matching `sourceInfo` metadata that 
 
 Once a companion tool is identified, its extension factory is loaded via jiti into a capture shim to obtain the full tool definition, which is then re-registered under the MCP alias name.
 
+## User-Defined Tool Aliases
+
+To register MCP-style aliases for flat-named tools from other installed extensions, create `~/.pi/agent/extensions/pi-claude-code-use.json` (global) or `<project>/.pi/extensions/pi-claude-code-use.json` (project). Schema:
+
+```json
+{
+  "toolAliases": [
+    ["subagent", "mcp__extension__subagent"]
+  ]
+}
+```
+
+The project file replaces the global file as a whole. Set `"toolAliases": []` in the project file to disable inherited globals.
+
 ## Core Tools Allowlist
 
 The following tool names always pass through filtering (case-insensitive). This list mirrors Pi core's `claudeCodeTools` in `packages/ai/src/providers/anthropic.ts`:

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -828,6 +828,7 @@ describe("pi-claude-code-use", () => {
 	it("registers MCP alias tools from companion extension factories", async () => {
 		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
 		const tempRoot = join(tempParent, "pi-exa-mcp");
+		const isolatedAgentDir = join(tempParent, "agent");
 		try {
 			const extDir = join(tempRoot, "extensions");
 			mkdirSync(extDir, { recursive: true });
@@ -855,7 +856,10 @@ describe("pi-claude-code-use", () => {
 				mockTool("web_search_exa", { baseDir: tempRoot, path: join(extDir, "index.js") }),
 			]);
 
-			await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI);
+			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
+				cwd: tempParent,
+				agentDir: isolatedAgentDir,
+			});
 
 			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__exa__web_search" }));
 		} finally {
@@ -864,16 +868,24 @@ describe("pi-claude-code-use", () => {
 	});
 
 	it("refuses to alias tools from unrelated packages even if names match", async () => {
-		const pi = createMockPi();
-		pi.getAllTools.mockReturnValue([
-			mockTool("generate_image", {
-				baseDir: "/tmp/node_modules/some-random-ext",
-				path: "/tmp/node_modules/some-random-ext/extensions/index.ts",
-			}),
-		]);
+		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		try {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("generate_image", {
+					baseDir: "/tmp/node_modules/some-random-ext",
+					path: "/tmp/node_modules/some-random-ext/extensions/index.ts",
+				}),
+			]);
 
-		await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI);
-		expect(pi.registerTool).not.toHaveBeenCalled();
+			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
+				cwd: tempParent,
+				agentDir: join(tempParent, "agent"),
+			});
+			expect(pi.registerTool).not.toHaveBeenCalled();
+		} finally {
+			rmSync(tempParent, { recursive: true, force: true });
+		}
 	});
 
 	// ----------------------------------------------------------------
@@ -969,7 +981,7 @@ describe("pi-claude-code-use", () => {
 			pi.getAllTools.mockReturnValue([mockTool("subagent", { baseDir: extDir, path: join(extDir, "index.js") })]);
 
 			try {
-				await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI, {
+				await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
 					cwd: projectDir,
 					agentDir,
 				});

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -54,6 +54,12 @@ function createMockPi() {
 	};
 }
 
+function getRegisteredHandler(pi: ReturnType<typeof createMockPi>, eventName: string) {
+	const call = pi.on.mock.calls.find(([event]) => event === eventName);
+	expect(call).toBeDefined();
+	return call?.[1] as (event: unknown, ctx: Record<string, unknown>) => Promise<unknown>;
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -63,6 +69,7 @@ describe("pi-claude-code-use", () => {
 		_test.registeredMcpAliases.clear();
 		_test.autoActivatedAliases.clear();
 		_test.setLastManagedToolList(undefined);
+		_test.refreshAliasMap([]);
 	});
 
 	// ----------------------------------------------------------------
@@ -89,6 +96,33 @@ describe("pi-claude-code-use", () => {
 		});
 
 		await expect(piClaudeCodeUse(pi as unknown as ExtensionAPI)).resolves.toBeUndefined();
+	});
+
+	it("uses the event cwd when loading project alias config", async () => {
+		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		const projectDir = join(tempParent, "project");
+		try {
+			vi.stubEnv("PI_CODING_AGENT_DIR", join(tempParent, "agent"));
+			const projectConfigPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
+			mkdirSync(dirname(projectConfigPath), { recursive: true });
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
+
+			const pi = createMockPi();
+			await piClaudeCodeUse(pi as unknown as ExtensionAPI);
+
+			const ctx = { cwd: projectDir, model: undefined };
+			const sessionStart = getRegisteredHandler(pi, "session_start");
+			await sessionStart({ type: "session_start" }, ctx);
+			expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__subagent__run");
+
+			_test.refreshAliasMap([]);
+			const beforeAgentStart = getRegisteredHandler(pi, "before_agent_start");
+			await beforeAgentStart({ type: "before_agent_start", prompt: "", systemPrompt: "" }, ctx);
+			expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__subagent__run");
+		} finally {
+			vi.unstubAllEnvs();
+			rmSync(tempParent, { recursive: true, force: true });
+		}
 	});
 
 	it("does not register alias tools when no companion source tools are loaded", async () => {
@@ -893,14 +927,18 @@ describe("pi-claude-code-use", () => {
 	// ----------------------------------------------------------------
 
 	describe("user-defined tool aliases", () => {
-		const testDir = join(process.cwd(), "test-cc-use-tmp");
-		const agentDir = join(testDir, "agent");
-		const projectDir = join(testDir, "project");
-		const globalConfigPath = join(agentDir, "extensions", "pi-claude-code-use.json");
-		const projectConfigPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
+		let testDir: string;
+		let agentDir: string;
+		let projectDir: string;
+		let globalConfigPath: string;
+		let projectConfigPath: string;
 
 		beforeEach(() => {
-			if (existsSync(testDir)) rmSync(testDir, { recursive: true });
+			testDir = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+			agentDir = join(testDir, "agent");
+			projectDir = join(testDir, "project");
+			globalConfigPath = join(agentDir, "extensions", "pi-claude-code-use.json");
+			projectConfigPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
 			mkdirSync(dirname(globalConfigPath), { recursive: true });
 			mkdirSync(dirname(projectConfigPath), { recursive: true });
 		});
@@ -954,6 +992,54 @@ describe("pi-claude-code-use", () => {
 			writeFileSync(globalConfigPath, JSON.stringify({ toolAliases: [["only_global", "mcp__g__one"]] }));
 			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
 			expect(load()).toEqual([]);
+		});
+
+		it("removes stale user aliases when project config changes", async () => {
+			const pi = createMockPi();
+
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
+			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
+				cwd: projectDir,
+				agentDir,
+			});
+
+			const withAlias = _test.transformPayload(
+				{
+					tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
+					tool_choice: { type: "tool", name: "subagent" },
+					messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
+				},
+				false,
+			);
+			expect(withAlias.tool_choice).toEqual({ type: "tool", name: "mcp__subagent__run" });
+			expect((withAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
+				"mcp__subagent__run",
+			);
+
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
+			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
+				cwd: projectDir,
+				agentDir,
+			});
+
+			const withoutAlias = _test.transformPayload(
+				{
+					tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
+					tool_choice: { type: "tool", name: "subagent" },
+					messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
+				},
+				false,
+			);
+			expect(withoutAlias.tool_choice).toBeUndefined();
+			expect((withoutAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
+				"subagent",
+			);
+
+			_test.registeredMcpAliases.add("mcp__subagent__run");
+			pi.getActiveTools.mockReturnValue(["subagent"]);
+			pi.getAllTools.mockReturnValue([mockTool("subagent"), mockTool("mcp__subagent__run")]);
+			_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+			expect(pi.setActiveTools).not.toHaveBeenCalled();
 		});
 
 		it("registers an MCP alias for a user-configured flat tool using its sourceInfo path", async () => {

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import piClaudeCodeUse, { _test } from "../extensions/index.js";
 
 // ============================================================================
@@ -874,5 +874,110 @@ describe("pi-claude-code-use", () => {
 
 		await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI);
 		expect(pi.registerTool).not.toHaveBeenCalled();
+	});
+
+	// ----------------------------------------------------------------
+	// User-defined tool aliases (pi-claude-code-use.json)
+	// ----------------------------------------------------------------
+
+	describe("user-defined tool aliases", () => {
+		const testDir = join(process.cwd(), "test-cc-use-tmp");
+		const agentDir = join(testDir, "agent");
+		const projectDir = join(testDir, "project");
+		const globalConfigPath = join(agentDir, "extensions", "pi-claude-code-use.json");
+		const projectConfigPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
+
+		beforeEach(() => {
+			if (existsSync(testDir)) rmSync(testDir, { recursive: true });
+			mkdirSync(dirname(globalConfigPath), { recursive: true });
+			mkdirSync(dirname(projectConfigPath), { recursive: true });
+		});
+
+		afterEach(() => {
+			if (existsSync(testDir)) rmSync(testDir, { recursive: true });
+		});
+
+		it("extractToolAliasPairs keeps string pairs and drops malformed entries", () => {
+			const pairs = _test.extractToolAliasPairs({
+				toolAliases: [["subagent", "mcp__subagent__run"], ["only-one"], "not-a-pair", [123, "mcp__bad__num"]],
+			});
+			expect(pairs).toEqual([["subagent", "mcp__subagent__run"]]);
+		});
+
+		const load = () => _test.loadToolAliases(projectDir, agentDir);
+
+		it("loadToolAliases: project file replaces global file", () => {
+			writeFileSync(
+				globalConfigPath,
+				JSON.stringify({
+					toolAliases: [
+						["subagent", "mcp__subagent__global"],
+						["only_global", "mcp__g__one"],
+					],
+				}),
+			);
+			writeFileSync(
+				projectConfigPath,
+				JSON.stringify({
+					toolAliases: [
+						["subagent", "mcp__subagent__project"],
+						["only_project", "mcp__p__one"],
+					],
+				}),
+			);
+
+			const pairs = load();
+			expect(pairs).toEqual([
+				["subagent", "mcp__subagent__project"],
+				["only_project", "mcp__p__one"],
+			]);
+		});
+
+		it("loadToolAliases falls back to global when project file is absent", () => {
+			writeFileSync(globalConfigPath, JSON.stringify({ toolAliases: [["only_global", "mcp__g__one"]] }));
+			expect(load()).toEqual([["only_global", "mcp__g__one"]]);
+		});
+
+		it("loadToolAliases: explicit empty project array disables inherited globals", () => {
+			writeFileSync(globalConfigPath, JSON.stringify({ toolAliases: [["only_global", "mcp__g__one"]] }));
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
+			expect(load()).toEqual([]);
+		});
+
+		it("registers an MCP alias for a user-configured flat tool using its sourceInfo path", async () => {
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
+
+			const extDir = join(projectDir, "my-subagent-ext");
+			mkdirSync(extDir, { recursive: true });
+			writeFileSync(
+				join(extDir, "index.js"),
+				[
+					'import { Type } from "typebox";',
+					"const schema = Type.Object({ task: Type.String() });",
+					"export default function subagentExt(pi) {",
+					"  pi.registerTool({",
+					'    name: "subagent",',
+					"    description: 'User-configured subagent tool',",
+					"    inputSchema: schema,",
+					"    async execute() { return { content: [{ type: 'text', text: 'ok' }] }; }",
+					"  });",
+					"}",
+				].join("\n"),
+			);
+
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([mockTool("subagent", { baseDir: extDir, path: join(extDir, "index.js") })]);
+
+			try {
+				await _test.registerAliasesForLoadedCompanions(pi as unknown as ExtensionAPI, {
+					cwd: projectDir,
+					agentDir,
+				});
+				expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__subagent__run" }));
+				expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__subagent__run");
+			} finally {
+				_test.FLAT_TO_MCP.delete("subagent");
+			}
+		});
 	});
 });

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -120,7 +120,11 @@ function readConfigFile(filePath: string): Record<string, unknown> {
 function extractToolAliasPairs(value: unknown): ToolAliasPair[] | undefined {
 	if (!isPlainObject(value)) return undefined;
 	const raw = (value as { toolAliases?: unknown }).toolAliases;
-	if (!Array.isArray(raw)) return undefined;
+	if (raw === undefined) return undefined;
+	if (!Array.isArray(raw)) {
+		console.warn(`[pi-claude-code-use] Ignoring "toolAliases": expected array, got ${typeof raw}`);
+		return undefined;
+	}
 	return raw.filter(
 		(e): e is ToolAliasPair => Array.isArray(e) && typeof e[0] === "string" && typeof e[1] === "string",
 	);
@@ -518,10 +522,7 @@ async function captureCompanionTools(baseDir: string, realPi: ExtensionAPI): Pro
 	return pending;
 }
 
-async function registerAliasesForLoadedCompanions(
-	pi: ExtensionAPI,
-	opts: { cwd?: string; agentDir?: string } = {},
-): Promise<void> {
+async function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: string } = {}): Promise<void> {
 	// Clear capture cache so flag/config changes since last call take effect
 	captureCache.clear();
 
@@ -656,11 +657,11 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 
 export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
 	pi.on("session_start", async () => {
-		await registerAliasesForLoadedCompanions(pi);
+		await registerMcpAliases(pi);
 	});
 
 	pi.on("before_agent_start", async (_event, ctx) => {
-		await registerAliasesForLoadedCompanions(pi);
+		await registerMcpAliases(pi);
 		const model = ctx.model;
 		const isOAuth = model?.provider === "anthropic" && ctx.modelRegistry.isUsingOAuth(model);
 		syncAliasActivation(pi, isOAuth);
@@ -702,7 +703,7 @@ export const _test = {
 	isPlainObject,
 	loadToolAliases,
 	lower,
-	registerAliasesForLoadedCompanions,
+	registerMcpAliases,
 	registeredMcpAliases,
 	remapMessageToolNames,
 	remapToolChoice,

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -53,14 +53,17 @@ const CORE_TOOL_NAMES = new Set([
 	"websearch",
 ]);
 
-/** Flat companion tool name → MCP-style alias. */
-const FLAT_TO_MCP = new Map<string, string>([
+/** Built-in flat companion tool name → MCP-style alias entries. */
+const BUILTIN_FLAT_TO_MCP_ENTRIES = [
 	["web_search_exa", "mcp__exa__web_search"],
 	["get_code_context_exa", "mcp__exa__get_code_context"],
 	["firecrawl_scrape", "mcp__firecrawl__scrape"],
 	["firecrawl_map", "mcp__firecrawl__map"],
 	["firecrawl_search", "mcp__firecrawl__search"],
-]);
+] as const;
+
+/** Flat tool name → MCP-style alias. Rebuilt from built-ins plus current user config. */
+const FLAT_TO_MCP = new Map<string, string>(BUILTIN_FLAT_TO_MCP_ENTRIES);
 
 /** Known companion extensions and the tools they provide. */
 const COMPANIONS: CompanionSpec[] = [
@@ -147,6 +150,16 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function lower(name: string | undefined): string {
 	return (name ?? "").trim().toLowerCase();
+}
+
+function refreshAliasMap(userToolAliases: ToolAliasPair[]): void {
+	FLAT_TO_MCP.clear();
+	for (const [flat, mcp] of BUILTIN_FLAT_TO_MCP_ENTRIES) {
+		FLAT_TO_MCP.set(lower(flat), mcp);
+	}
+	for (const [flat, mcp] of userToolAliases) {
+		FLAT_TO_MCP.set(lower(flat), mcp);
+	}
 }
 
 // ============================================================================
@@ -529,7 +542,7 @@ async function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentD
 	// Pick up user-defined tool aliases from settings.json so subsequent payload
 	// transforms (filterAndRemapTools, remapToolChoice, message rewriting) see them.
 	const userToolAliases = loadToolAliases(opts.cwd ?? process.cwd(), opts.agentDir);
-	for (const [flat, mcp] of userToolAliases) FLAT_TO_MCP.set(lower(flat), mcp);
+	refreshAliasMap(userToolAliases);
 
 	const allTools = pi.getAllTools();
 	const toolIndex = new Map<string, ToolInfo>();
@@ -656,12 +669,12 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 // ============================================================================
 
 export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
-	pi.on("session_start", async () => {
-		await registerMcpAliases(pi);
+	pi.on("session_start", async (_event, ctx) => {
+		await registerMcpAliases(pi, { cwd: ctx.cwd });
 	});
 
 	pi.on("before_agent_start", async (_event, ctx) => {
-		await registerMcpAliases(pi);
+		await registerMcpAliases(pi, { cwd: ctx.cwd });
 		const model = ctx.model;
 		const isOAuth = model?.provider === "anthropic" && ctx.modelRegistry.isUsingOAuth(model);
 		syncAliasActivation(pi, isOAuth);
@@ -703,6 +716,7 @@ export const _test = {
 	isPlainObject,
 	loadToolAliases,
 	lower,
+	refreshAliasMap,
 	registerMcpAliases,
 	registeredMcpAliases,
 	remapMessageToolNames,

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -1,11 +1,11 @@
-import { appendFileSync } from "node:fs";
-import { basename, dirname } from "node:path";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { createJiti } from "@mariozechner/jiti";
 import * as piAgentCoreModule from "@mariozechner/pi-agent-core";
 import * as piAiModule from "@mariozechner/pi-ai";
 import * as piAiOauthModule from "@mariozechner/pi-ai/oauth";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import * as piCodingAgentModule from "@mariozechner/pi-coding-agent";
+import { type ExtensionAPI, getAgentDir } from "@mariozechner/pi-coding-agent";
 import * as piTuiModule from "@mariozechner/pi-tui";
 import * as typeboxModule from "typebox";
 import * as typeboxCompileModule from "typebox/compile";
@@ -87,6 +87,51 @@ const COMPANIONS: CompanionSpec[] = [
 const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
 	COMPANIONS.flatMap((spec) => spec.aliases.map(([flat]) => [flat, spec] as const)),
 );
+
+// ============================================================================
+// User-defined tool aliases (pi-claude-code-use.json)
+//
+//   - project: <cwd>/.pi/extensions/pi-claude-code-use.json
+//   - global:  <agentDir>/extensions/pi-claude-code-use.json   (agentDir from pi)
+//
+// Project file's keys replace global file's via spread-merge — same effective
+// behaviour as pi-core's deepMergeSettings for our top-level array key.
+// Schema: { "toolAliases": [[flat, mcp], ...] }
+// ============================================================================
+
+const CONFIG_FILENAME = "pi-claude-code-use.json";
+
+type ToolAliasPair = readonly [flatName: string, mcpName: string];
+
+function readConfigFile(filePath: string): Record<string, unknown> {
+	if (!existsSync(filePath)) return {};
+	try {
+		const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+		return isPlainObject(parsed) ? parsed : {};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`[pi-claude-code-use] Failed to read ${filePath}: ${message}`);
+		return {};
+	}
+}
+
+// Returns `undefined` when `toolAliases` is missing or not an array; returns
+// `[]` for an explicit empty array (which disables inherited globals).
+function extractToolAliasPairs(value: unknown): ToolAliasPair[] | undefined {
+	if (!isPlainObject(value)) return undefined;
+	const raw = (value as { toolAliases?: unknown }).toolAliases;
+	if (!Array.isArray(raw)) return undefined;
+	return raw.filter(
+		(e): e is ToolAliasPair => Array.isArray(e) && typeof e[0] === "string" && typeof e[1] === "string",
+	);
+}
+
+function loadToolAliases(cwd: string, agentDir: string = getAgentDir()): ToolAliasPair[] {
+	const globalPath = join(agentDir, "extensions", CONFIG_FILENAME);
+	const projectPath = join(cwd, ".pi", "extensions", CONFIG_FILENAME);
+	const merged = { ...readConfigFile(globalPath), ...readConfigFile(projectPath) };
+	return extractToolAliasPairs(merged) ?? [];
+}
 
 // ============================================================================
 // Helpers
@@ -473,9 +518,17 @@ async function captureCompanionTools(baseDir: string, realPi: ExtensionAPI): Pro
 	return pending;
 }
 
-async function registerAliasesForLoadedCompanions(pi: ExtensionAPI): Promise<void> {
+async function registerAliasesForLoadedCompanions(
+	pi: ExtensionAPI,
+	opts: { cwd?: string; agentDir?: string } = {},
+): Promise<void> {
 	// Clear capture cache so flag/config changes since last call take effect
 	captureCache.clear();
+
+	// Pick up user-defined tool aliases from settings.json so subsequent payload
+	// transforms (filterAndRemapTools, remapToolChoice, message rewriting) see them.
+	const userToolAliases = loadToolAliases(opts.cwd ?? process.cwd(), opts.agentDir);
+	for (const [flat, mcp] of userToolAliases) FLAT_TO_MCP.set(lower(flat), mcp);
 
 	const allTools = pi.getAllTools();
 	const toolIndex = new Map<string, ToolInfo>();
@@ -485,31 +538,37 @@ async function registerAliasesForLoadedCompanions(pi: ExtensionAPI): Promise<voi
 		knownNames.add(lower(tool.name));
 	}
 
+	// Loads the source extension via jiti and re-registers its captured tool
+	// definition under `mcpName`. Skips if already registered or unloadable.
+	const registerMcpAlias = async (tool: ToolInfo | undefined, flatName: string, mcpName: string): Promise<void> => {
+		if (!tool || registeredMcpAliases.has(mcpName) || knownNames.has(lower(mcpName))) return;
+		// Prefer the extension file's directory (sourceInfo.path is the actual entry
+		// point). Fall back to baseDir, which can be the monorepo root.
+		const loadDir = tool.sourceInfo?.path ? dirname(tool.sourceInfo.path) : tool.sourceInfo?.baseDir;
+		if (!loadDir) return;
+		const def = (await captureCompanionTools(loadDir, pi)).get(flatName);
+		if (!def) return;
+		pi.registerTool({
+			...def,
+			name: mcpName,
+			label: def.label?.startsWith("MCP ") ? def.label : `MCP ${def.label ?? mcpName}`,
+		});
+		registeredMcpAliases.add(mcpName);
+		knownNames.add(lower(mcpName));
+	};
+
+	// Built-in companion aliases: gated by source-info match against COMPANIONS.
 	for (const spec of COMPANIONS) {
 		for (const [flatName, mcpName] of spec.aliases) {
-			if (registeredMcpAliases.has(mcpName) || knownNames.has(lower(mcpName))) continue;
-
 			const tool = toolIndex.get(lower(flatName));
-			if (!tool || !isCompanionSource(tool, spec)) continue;
-
-			// Prefer the extension file's directory for loading (sourceInfo.path is the actual
-			// entry point). Fall back to baseDir only if path is unavailable. baseDir can be
-			// the monorepo root which doesn't contain the extension entry point directly.
-			const loadDir = tool.sourceInfo?.path ? dirname(tool.sourceInfo.path) : tool.sourceInfo?.baseDir;
-			if (!loadDir) continue;
-
-			const captured = await captureCompanionTools(loadDir, pi);
-			const def = captured.get(flatName);
-			if (!def) continue;
-
-			pi.registerTool({
-				...def,
-				name: mcpName,
-				label: def.label?.startsWith("MCP ") ? def.label : `MCP ${def.label ?? mcpName}`,
-			});
-			registeredMcpAliases.add(mcpName);
-			knownNames.add(lower(mcpName));
+			if (tool && !isCompanionSource(tool, spec)) continue;
+			await registerMcpAlias(tool, flatName, mcpName);
 		}
+	}
+
+	// User-defined aliases: matched by flat name only.
+	for (const [flatName, mcpName] of userToolAliases) {
+		await registerMcpAlias(toolIndex.get(lower(flatName)), flatName, mcpName);
 	}
 }
 
@@ -636,10 +695,12 @@ export const _test = {
 	autoActivatedAliases,
 	buildCaptureShim,
 	collectToolNames,
+	extractToolAliasPairs,
 	filterAndRemapTools,
 	getLastManagedToolList: () => lastManagedToolList,
 	isCompanionSource,
 	isPlainObject,
+	loadToolAliases,
 	lower,
 	registerAliasesForLoadedCompanions,
 	registeredMcpAliases,

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-claude-code-use",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
   "keywords": [
     "pi",


### PR DESCRIPTION
The package already aliases sibling `@benvargas/pi-*` companion tools to `mcp__...` names so they survive Anthropic OAuth tool-name filtering. Tools registered by any other extension (third-party packages, locally-loaded examples, in-house extensions) get filtered out unless the user edits the `COMPANIONS` const in source. This PR lets users register their own aliases without touching extension code.

Users add `[flatName, mcpName]` pairs to a dedicated config file:

- `<agentDir>/extensions/pi-claude-code-use.json` (global)
- `<cwd>/.pi/extensions/pi-claude-code-use.json` (project, replaces global)

Schema:

```json
{ "toolAliases": [["subagent", "mcp__extension__subagent"]] }
```

Each pair causes the package to look up the flat-named tool in `pi.getAllTools()`, load its source extension via the existing jiti shim, and re-register the captured tool definition under the configured MCP name. Subsequent payload transforms (`filterAndRemapTools`, `remapToolChoice`, message-history rewriting) then route through the alias.

The config layout, filename pattern, and load semantics mirror the existing sibling extensions (`pi-openai-fast`, `pi-firecrawl`, `pi-exa-mcp`, `pi-model-shortcuts`):

- `getAgentDir()` from `pi-coding-agent` so `PI_CODING_AGENT_DIR` is honored.
- `existsSync` + `readFileSync` + `JSON.parse` with `console.warn` on parse error.
- Spread merge `{ ...global, ...project }`. For our top-level array schema this matches pi-core's `deepMergeSettings` exactly: project arrays replace global arrays; explicit `"toolAliases": []` in project disables inherited globals.
- `extractToolAliasPairs` distinguishes "key missing" (undefined → fall through) from "empty array" (explicit clear).

Refactor in `registerAliasesForLoadedCompanions` (renamed to `registerMcpAliases`): extracted a local `registerMcpAlias` helper to share the load-and-register pipeline between the existing built-in `COMPANIONS` loop and the new user-aliases loop. The built-in loop still gates on `isCompanionSource`; the user loop matches by flat name only since the config is the user's explicit opt-in. Behaviour preserved for the existing companion path.

## Validation

- `npm run check` (biome + tsc) clean
- `npm run test` passes (139 tests; +5 covering the new feature: parser contract, project replaces global, fallback to global, explicit empty disables, end-to-end registration)
- Live exercise via dotfiles: `subagent` tool from pi-coding-agent's example extension registered as `mcp__extension__subagent` through project `pi-claude-code-use.json` and invoked successfully under Anthropic OAuth.

---

The second commit (`refactor(pi-claude-code-use): address review feedback on user-aliases`) addresses three small points from a parallel review pass run with `claude-opus-4-7` and `openai-codex/gpt-5.5`: rename `registerAliasesForLoadedCompanions` → `registerMcpAliases` (the function now also handles user aliases), `console.warn` when project `toolAliases` is present but not an array (instead of silently suppressing the global), and pass explicit `cwd`/`agentDir` to two pre-existing companion tests so they don't read the developer's real `~/.pi/agent/extensions/pi-claude-code-use.json`. No behaviour change for users.