### PR TITLE
feat(pi-claude-code-use): unalias tool calls on message_end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5511,7 +5511,7 @@
     },
     "packages/pi-claude-code-use": {
       "name": "@benvargas/pi-claude-code-use",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.5"

--- a/packages/pi-claude-code-use/CHANGELOG.md
+++ b/packages/pi-claude-code-use/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-05-21
+
+### Added
+- Rewrites managed MCP alias `toolCall` names back to their canonical flat tool names during `message_end`, so Pi executes the original extension tool rather than the captured alias duplicate.
+- Added regression coverage to ensure direct MCP tools from other extensions are not rewritten.
+
 ## [1.0.3] - 2026-05-07
 
 ### Changed

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -17,7 +17,8 @@ When Pi is using Anthropic OAuth, this extension intercepts outbound API request
 - **Companion tool remapping** -- renames known companion extension tools from their flat names to MCP-style aliases (e.g. `web_search_exa` becomes `mcp__exa__web_search`). Duplicate flat entries are removed after remapping.
 - **tool_choice remapping** -- if `tool_choice` references a flat companion name that was remapped, the reference is updated to the MCP alias. If it references a tool that was filtered out, `tool_choice` is removed from the payload.
 - **Message history rewriting** -- `tool_use` blocks in conversation history that reference flat companion names are rewritten to their MCP aliases so the model sees consistent tool names across the conversation.
-- **Companion alias registration** -- at session start and before each agent turn, discovers loaded companion extensions, captures their tool definitions via a jiti-based shim, and registers MCP-alias copies so the model can invoke them under Claude Code-compatible names.
+- **Companion alias registration** -- at session start and before each agent turn, discovers loaded companion extensions, captures their tool definitions via a jiti-based shim, and registers MCP-alias copies so Anthropic sees Claude Code-compatible names.
+- **Managed tool-call unaliasing** -- when the model calls an MCP alias registered by this extension, rewrites the finalized `toolCall` name back to the original flat tool name during `message_end`, before Pi resolves execution. Direct MCP tools from other extensions are left untouched.
 - **Alias activation tracking** -- auto-activates MCP aliases when their flat counterpart is active under Anthropic OAuth. Tracks provenance (auto-managed vs user-selected) so that disabling OAuth only removes auto-activated aliases, preserving any the user explicitly enabled.
 
 Non-OAuth Anthropic usage and non-Anthropic providers are left completely unchanged.
@@ -77,7 +78,7 @@ The extension identifies companion tools by matching `sourceInfo` metadata that 
 1. **baseDir match** -- if the tool's `sourceInfo.baseDir` directory name matches the companion's directory name (e.g. `pi-exa-mcp`).
 2. **Path match** -- if the tool's `sourceInfo.path` contains the companion's scoped package name (e.g. `@benvargas/pi-exa-mcp`) or directory name as a path segment. This handles npm installs, git clones, and monorepo layouts where `baseDir` points to the repo root rather than the individual package.
 
-Once a companion tool is identified, its extension factory is loaded via jiti into a capture shim to obtain the full tool definition, which is then re-registered under the MCP alias name.
+Once a companion tool is identified, its extension factory is loaded via jiti into a capture shim to obtain the full tool definition, which is then re-registered under the MCP alias name. Those alias copies are model-facing compatibility shims; when the assistant actually calls one of these managed aliases, `pi-claude-code-use` rewrites the finalized `toolCall` back to the original flat name before Pi executes the tool. This preserves the source extension's original `execute` closure and state.
 
 ## User-Defined Tool Aliases
 
@@ -94,6 +95,8 @@ To register MCP-style aliases for flat-named tools from other installed extensio
 
 Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; choose an MCP alias in the form `mcp__<namespace>__<tool>`.
 
+Aliases registered through this config are treated the same as the built-in companion aliases: Anthropic sees the MCP-style name, but managed alias calls are canonicalized back to the flat source tool before local execution. MCP-style tools that are provided directly by another extension are not rewritten unless `pi-claude-code-use` registered that same alias.
+
 The project file replaces the global file as a whole. Set `"toolAliases": []` in the project file to disable inherited globals.
 
 ## Core Tools Allowlist
@@ -102,7 +105,7 @@ The following tool names always pass through filtering (case-insensitive). This 
 
 `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode`, `KillShell`, `NotebookEdit`, `Skill`, `Task`, `TaskOutput`, `TodoWrite`, `WebFetch`, `WebSearch`
 
-Additionally, any tool with a `type` field (Anthropic-native tools like `web_search`) and any tool prefixed with `mcp__` always passes through.
+Additionally, any tool with a `type` field (Anthropic-native tools like `web_search`) and any tool prefixed with `mcp__` always passes through provider-request filtering. Direct MCP tools remain direct MCP tools; only aliases registered by `pi-claude-code-use` are rewritten back to flat names before local execution.
 
 ## Guidance For Extension Authors
 

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -1078,4 +1078,97 @@ describe("pi-claude-code-use", () => {
 			}
 		});
 	});
+
+	describe("unaliasToolCalls (message_end intercept)", () => {
+		it("rewrites a toolCall block's MCP-aliased name back to its flat counterpart", () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+
+			const msg = {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "running the chain" },
+					{ type: "toolCall", id: "call_1", name: "mcp__chain__run_chain", arguments: { task: "ping" } },
+				],
+			};
+
+			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+			expect(out).toBeDefined();
+			expect(out?.content[1]).toEqual({
+				type: "toolCall",
+				id: "call_1",
+				name: "run_chain",
+				arguments: { task: "ping" },
+			});
+			// Original message must not be mutated.
+			expect((msg.content[1] as { name: string }).name).toBe("mcp__chain__run_chain");
+		});
+
+		it("returns undefined when no toolCall name needs rewriting", () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+
+			const msg = {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "just text" },
+					{ type: "toolCall", id: "call_1", name: "run_chain", arguments: {} },
+				],
+			};
+
+			expect(_test.unaliasToolCalls(msg)).toBeUndefined();
+		});
+
+		it("ignores non-assistant messages", () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+			expect(
+				_test.unaliasToolCalls({
+					role: "user",
+					content: [{ type: "toolCall", id: "x", name: "mcp__chain__run_chain", arguments: {} }],
+				}),
+			).toBeUndefined();
+		});
+
+		it("rewrites multiple toolCall blocks in one message", () => {
+			_test.refreshAliasMap([
+				["run_chain", "mcp__chain__run_chain"],
+				["query_experts", "mcp__pipi__query_experts"],
+			]);
+
+			const msg = {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "a", name: "mcp__chain__run_chain", arguments: {} },
+					{ type: "toolCall", id: "b", name: "mcp__pipi__query_experts", arguments: {} },
+					{ type: "toolCall", id: "c", name: "some_other_tool", arguments: {} },
+				],
+			};
+
+			const out = _test.unaliasToolCalls(msg) as typeof msg;
+			expect((out.content[0] as { name: string }).name).toBe("run_chain");
+			expect((out.content[1] as { name: string }).name).toBe("query_experts");
+			expect((out.content[2] as { name: string }).name).toBe("some_other_tool");
+		});
+
+		it("is wired up as a message_end handler", async () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([mockTool("run_chain")]);
+			await piClaudeCodeUse(pi as unknown as ExtensionAPI);
+
+			const handler = getRegisteredHandler(pi, "message_end");
+			expect(handler).toBeDefined();
+
+			const event = {
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call_1", name: "mcp__chain__run_chain", arguments: { task: "ping" } }],
+				},
+			};
+
+			const result = (await handler(event, { cwd: "/tmp" })) as { message: { content: Array<{ name?: string }> } };
+			expect(result).toBeDefined();
+			expect(result.message.content[0].name).toBe("run_chain");
+		});
+	});
 });

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -754,6 +754,51 @@ describe("pi-claude-code-use", () => {
 		expect(pi.setActiveTools).not.toHaveBeenCalled();
 	});
 
+	it("recognizes mixed-case mcp aliases from user config (case-insensitive registeredMcpAliases lookups)", () => {
+		const pi = createMockPi();
+		// refreshAliasMap stores the mcp value RAW (mixed-case), simulating a user
+		// who put ["my_tool", "MCP__Foo__Bar"] in their pi-claude-code-use.json.
+		_test.refreshAliasMap([["my_tool", "MCP__Foo__Bar"]]);
+		// registerMcpAlias normalizes via lower(mcpName) before adding; mirror that here.
+		_test.registeredMcpAliases.add("mcp__foo__bar");
+		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
+		pi.getActiveTools.mockReturnValue(["read", "my_tool"]);
+
+		// Enable: line 647 must recognize the registered alias despite mixed case
+		// and append it to active tools.
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "my_tool", "MCP__Foo__Bar"]);
+
+		// Disable: removes the auto-activated mixed-case alias via the
+		// autoActivatedAliases set populated during the enable pass above.
+		// (This branch does not traverse lines 673/681; line 647 is the
+		// site this test locks in.)
+		pi.setActiveTools.mockClear();
+		pi.getActiveTools.mockReturnValue(["read", "my_tool", "MCP__Foo__Bar"]);
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "my_tool"]);
+	});
+
+	it("preserves user-selected mixed-case mcp aliases on sync (line 673)", () => {
+		const pi = createMockPi();
+		_test.refreshAliasMap([["my_tool", "MCP__Foo__Bar"]]);
+		// registerMcpAlias normalizes via lower(mcpName) before adding; mirror that here.
+		_test.registeredMcpAliases.add("mcp__foo__bar");
+		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
+		// User manually selected the mixed-case alias via the tool picker.
+		// Flat counterpart is NOT active — auto-activation path (line 647) is skipped,
+		// forcing the preserve-user-selected path through line 673.
+		pi.getActiveTools.mockReturnValue(["read", "MCP__Foo__Bar"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+
+		// With lower() at line 673, the alias is recognized as registered → preserved
+		// → next === activeNames → setActiveTools is NOT called.
+		// Without lower(), the alias is dropped from activeRegistered → next = ["read"]
+		// → setActiveTools(["read"]) is called, silently breaking the user's selection.
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+	});
+
 	// ----------------------------------------------------------------
 	// Capture shim
 	// ----------------------------------------------------------------
@@ -1082,6 +1127,7 @@ describe("pi-claude-code-use", () => {
 	describe("unaliasToolCalls (message_end intercept)", () => {
 		it("rewrites a toolCall block's MCP-aliased name back to its flat counterpart", () => {
 			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+			_test.registeredMcpAliases.add("mcp__chain__run_chain");
 
 			const msg = {
 				role: "assistant",
@@ -1132,6 +1178,8 @@ describe("pi-claude-code-use", () => {
 				["run_chain", "mcp__chain__run_chain"],
 				["query_experts", "mcp__pipi__query_experts"],
 			]);
+			_test.registeredMcpAliases.add("mcp__chain__run_chain");
+			_test.registeredMcpAliases.add("mcp__pipi__query_experts");
 
 			const msg = {
 				role: "assistant",
@@ -1150,6 +1198,7 @@ describe("pi-claude-code-use", () => {
 
 		it("is wired up as a message_end handler", async () => {
 			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+			_test.registeredMcpAliases.add("mcp__chain__run_chain");
 
 			const pi = createMockPi();
 			pi.getAllTools.mockReturnValue([mockTool("run_chain")]);
@@ -1169,6 +1218,82 @@ describe("pi-claude-code-use", () => {
 			const result = (await handler(event, { cwd: "/tmp" })) as { message: { content: Array<{ name?: string }> } };
 			expect(result).toBeDefined();
 			expect(result.message.content[0].name).toBe("run_chain");
+		});
+
+		it("leaves foreign mcp__ toolCalls untouched when registeredMcpAliases is empty", () => {
+			// refreshAliasMap re-seeds builtins (including mcp__exa__web_search → web_search_exa)
+			// but registeredMcpAliases is cleared by the top-level beforeEach and not populated here.
+			_test.refreshAliasMap([]);
+
+			const msg = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "x", name: "mcp__exa__web_search", arguments: {} }],
+			};
+
+			expect(_test.unaliasToolCalls(msg)).toBeUndefined();
+		});
+
+		it("rewrites mcp__exa__web_search → web_search_exa when registered by this extension", () => {
+			_test.refreshAliasMap([]);
+			_test.registeredMcpAliases.add("mcp__exa__web_search");
+
+			const msg = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "y", name: "mcp__exa__web_search", arguments: {} }],
+			};
+
+			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+			expect(out).toBeDefined();
+			expect((out?.content[0] as { name: string }).name).toBe("web_search_exa");
+		});
+
+		it("in a mixed message, only registered aliases are rewritten; foreign mcp__ names are preserved", () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+			// Register only the user-defined alias; the builtin exa alias is NOT registered.
+			_test.registeredMcpAliases.add("mcp__chain__run_chain");
+
+			const msg = {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "a", name: "mcp__chain__run_chain", arguments: {} },
+					{ type: "toolCall", id: "b", name: "mcp__exa__web_search", arguments: {} },
+				],
+			};
+
+			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+			expect(out).toBeDefined();
+			expect((out?.content[0] as { name: string }).name).toBe("run_chain");
+			expect((out?.content[1] as { name: string }).name).toBe("mcp__exa__web_search");
+		});
+
+		it("leaves user-defined mcp__ toolCalls untouched when not registered by this extension", () => {
+			// Seed MCP_TO_FLAT with a user alias entry, but do NOT add it to
+			// registeredMcpAliases. Simulates a model emitting an alias name that
+			// another extension actually owns — this extension must not rewrite it.
+			_test.refreshAliasMap([["my_custom_tool", "mcp__custom__do_thing"]]);
+			_test.registeredMcpAliases.clear();
+
+			const msg = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "1", name: "mcp__custom__do_thing", arguments: {} }],
+			};
+
+			expect(_test.unaliasToolCalls(msg)).toBeUndefined();
+		});
+
+		it("rewrites mixed-case mcp__ toolCall names (case-insensitive lookup)", () => {
+			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
+			_test.registeredMcpAliases.clear();
+			_test.registeredMcpAliases.add("mcp__chain__run_chain");
+
+			const msg = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "z", name: "MCP__Chain__Run_Chain", arguments: {} }],
+			};
+
+			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+			expect(out).toBeDefined();
+			expect((out?.content[0] as { name: string }).name).toBe("run_chain");
 		});
 	});
 });

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -764,35 +764,34 @@ describe("pi-claude-code-use", () => {
 		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
 		pi.getActiveTools.mockReturnValue(["read", "my_tool"]);
 
-		// Enable: line 647 must recognize the registered alias despite mixed case
-		// and append it to active tools.
+		// Enable must recognize the registered alias despite mixed case and append
+		// it to active tools.
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "my_tool", "MCP__Foo__Bar"]);
 
 		// Disable: removes the auto-activated mixed-case alias via the
 		// autoActivatedAliases set populated during the enable pass above.
-		// (This branch does not traverse lines 673/681; line 647 is the
-		// site this test locks in.)
+		// This branch locks in the auto-activation lookup.
 		pi.setActiveTools.mockClear();
 		pi.getActiveTools.mockReturnValue(["read", "my_tool", "MCP__Foo__Bar"]);
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "my_tool"]);
 	});
 
-	it("preserves user-selected mixed-case mcp aliases on sync (line 673)", () => {
+	it("preserves user-selected mixed-case mcp aliases on sync", () => {
 		const pi = createMockPi();
 		_test.refreshAliasMap([["my_tool", "MCP__Foo__Bar"]]);
 		// registerMcpAlias normalizes via lower(mcpName) before adding; mirror that here.
 		_test.registeredMcpAliases.add("mcp__foo__bar");
 		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
 		// User manually selected the mixed-case alias via the tool picker.
-		// Flat counterpart is NOT active — auto-activation path (line 647) is skipped,
-		// forcing the preserve-user-selected path through line 673.
+		// Flat counterpart is NOT active, so this exercises the preserve
+		// user-selected path instead of auto-activation.
 		pi.getActiveTools.mockReturnValue(["read", "MCP__Foo__Bar"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 
-		// With lower() at line 673, the alias is recognized as registered → preserved
+		// With lower(), the alias is recognized as registered → preserved
 		// → next === activeNames → setActiveTools is NOT called.
 		// Without lower(), the alias is dropped from activeRegistered → next = ["read"]
 		// → setActiveTools(["read"]) is called, silently breaking the user's selection.

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -154,12 +154,56 @@ function lower(name: string | undefined): string {
 
 function refreshAliasMap(userToolAliases: ToolAliasPair[]): void {
 	FLAT_TO_MCP.clear();
+	MCP_TO_FLAT.clear();
 	for (const [flat, mcp] of BUILTIN_FLAT_TO_MCP_ENTRIES) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
+		MCP_TO_FLAT.set(lower(mcp), flat);
 	}
 	for (const [flat, mcp] of userToolAliases) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
+		MCP_TO_FLAT.set(lower(mcp), flat);
 	}
+}
+
+// Reverse map: MCP-prefixed alias (lowercase) → canonical flat name.
+// Populated alongside FLAT_TO_MCP. Used by `unaliasToolCalls`.
+const MCP_TO_FLAT = new Map<string, string>();
+for (const [flat, mcp] of BUILTIN_FLAT_TO_MCP_ENTRIES) {
+	MCP_TO_FLAT.set(lower(mcp), flat);
+}
+
+// Rewrite `name` on every block of `blockType` via `mapName`. Returns the
+// SAME array reference when nothing changed, so callers can use reference
+// equality to skip spreading the parent object.
+function remapBlockNames(
+	content: unknown[],
+	blockType: "tool_use" | "toolCall",
+	mapName: (name: string) => string | undefined,
+): unknown[] {
+	let changed = false;
+	const next = content.map((block) => {
+		if (!isPlainObject(block) || block.type !== blockType || typeof block.name !== "string") {
+			return block;
+		}
+		const newName = mapName(block.name);
+		if (!newName || newName === block.name) return block;
+		changed = true;
+		return { ...block, name: newName };
+	});
+	return changed ? next : content;
+}
+
+// Rewrite MCP-aliased `toolCall.name`s in the finalized assistant message
+// back to their canonical flat names. Fires from `message_end`, which runs
+// BEFORE the agent loop resolves which tool to invoke — so Pi looks up the
+// ORIGINAL extension's `execute` (preserving its closure-bound state) instead
+// of pi-claude-code-use's jiti-loaded duplicate. Inverse of `remapMessageToolNames`.
+function unaliasToolCalls(message: unknown): unknown {
+	if (!isPlainObject(message) || message.role !== "assistant" || !Array.isArray(message.content)) {
+		return undefined;
+	}
+	const content = remapBlockNames(message.content, "toolCall", (n) => MCP_TO_FLAT.get(lower(n)));
+	return content === message.content ? undefined : { ...message, content };
 }
 
 // ============================================================================
@@ -306,27 +350,14 @@ function remapMessageToolNames(messages: unknown[], survivingNames: Map<string, 
 	let anyChanged = false;
 	const result = messages.map((msg) => {
 		if (!isPlainObject(msg) || !Array.isArray(msg.content)) return msg;
-
-		let msgChanged = false;
-		const content = (msg.content as unknown[]).map((block) => {
-			if (!isPlainObject(block) || block.type !== "tool_use" || typeof block.name !== "string") {
-				return block;
-			}
-			const mcpAlias = FLAT_TO_MCP.get(lower(block.name));
-			if (mcpAlias && survivingNames.has(lower(mcpAlias))) {
-				msgChanged = true;
-				return { ...block, name: mcpAlias };
-			}
-			return block;
+		const content = remapBlockNames(msg.content, "tool_use", (n) => {
+			const alias = FLAT_TO_MCP.get(lower(n));
+			return alias && survivingNames.has(lower(alias)) ? alias : undefined;
 		});
-
-		if (msgChanged) {
-			anyChanged = true;
-			return { ...msg, content };
-		}
-		return msg;
+		if (content === msg.content) return msg;
+		anyChanged = true;
+		return { ...msg, content };
 	});
-
 	return anyChanged ? result : messages;
 }
 
@@ -685,6 +716,13 @@ export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
 		syncAliasActivation(pi, isOAuth);
 	});
 
+	// MCP alias → flat canonical name before the agent loop resolves the tool.
+	pi.on("message_end", async (event, _ctx) => {
+		const rewritten = unaliasToolCalls(event.message);
+		if (!rewritten) return undefined;
+		return { message: rewritten as typeof event.message };
+	});
+
 	pi.on("before_provider_request", (event, ctx) => {
 		const model = ctx.model;
 		if (!model || model.provider !== "anthropic" || !ctx.modelRegistry.isUsingOAuth(model)) {
@@ -708,6 +746,7 @@ export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
 
 export const _test = {
 	CORE_TOOL_NAMES,
+	MCP_TO_FLAT,
 	FLAT_TO_MCP,
 	COMPANIONS,
 	TOOL_TO_COMPANION,
@@ -733,4 +772,5 @@ export const _test = {
 	},
 	syncAliasActivation,
 	transformPayload,
+	unaliasToolCalls,
 };

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -198,11 +198,19 @@ function remapBlockNames(
 // BEFORE the agent loop resolves which tool to invoke — so Pi looks up the
 // ORIGINAL extension's `execute` (preserving its closure-bound state) instead
 // of pi-claude-code-use's jiti-loaded duplicate. Inverse of `remapMessageToolNames`.
+//
+// Gated on `registeredMcpAliases`: only rewrites names that this extension
+// explicitly registered, so foreign mcp__ tools (owned by other extensions)
+// pass through untouched.
 function unaliasToolCalls(message: unknown): unknown {
 	if (!isPlainObject(message) || message.role !== "assistant" || !Array.isArray(message.content)) {
 		return undefined;
 	}
-	const content = remapBlockNames(message.content, "toolCall", (n) => MCP_TO_FLAT.get(lower(n)));
+	const content = remapBlockNames(message.content, "toolCall", (n) => {
+		const flat = MCP_TO_FLAT.get(lower(n));
+		if (!flat || !registeredMcpAliases.has(lower(n))) return undefined;
+		return flat;
+	});
 	return content === message.content ? undefined : { ...message, content };
 }
 
@@ -591,7 +599,7 @@ async function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentD
 	// Loads the source extension via jiti and re-registers its captured tool
 	// definition under `mcpName`. Skips if already registered or unloadable.
 	const registerMcpAlias = async (tool: ToolInfo | undefined, flatName: string, mcpName: string): Promise<void> => {
-		if (!tool || registeredMcpAliases.has(mcpName) || knownNames.has(lower(mcpName))) return;
+		if (!tool || registeredMcpAliases.has(lower(mcpName)) || knownNames.has(lower(mcpName))) return;
 		// Prefer the extension file's directory (sourceInfo.path is the actual entry
 		// point). Fall back to baseDir, which can be the monorepo root.
 		const loadDir = tool.sourceInfo?.path ? dirname(tool.sourceInfo.path) : tool.sourceInfo?.baseDir;
@@ -603,7 +611,7 @@ async function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentD
 			name: mcpName,
 			label: def.label?.startsWith("MCP ") ? def.label : `MCP ${def.label ?? mcpName}`,
 		});
-		registeredMcpAliases.add(mcpName);
+		registeredMcpAliases.add(lower(mcpName));
 		knownNames.add(lower(mcpName));
 	};
 
@@ -636,7 +644,7 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		const activeLc = new Set(activeNames.map(lower));
 		const desiredAliases: string[] = [];
 		for (const [flat, mcp] of FLAT_TO_MCP) {
-			if (activeLc.has(flat) && allNames.has(mcp) && registeredMcpAliases.has(mcp)) {
+			if (activeLc.has(flat) && allNames.has(mcp) && registeredMcpAliases.has(lower(mcp))) {
 				desiredAliases.push(mcp);
 			}
 		}
@@ -662,7 +670,7 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		}
 
 		// Find registered aliases currently in the active list
-		const activeRegistered = activeNames.filter((n) => registeredMcpAliases.has(n) && allNames.has(n));
+		const activeRegistered = activeNames.filter((n) => registeredMcpAliases.has(lower(n)) && allNames.has(n));
 
 		// Per-alias provenance: an alias is "user-selected" if it's active and was NOT
 		// auto-activated by us. Only preserve those; auto-activated aliases get re-derived
@@ -670,7 +678,7 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		const preserved = activeRegistered.filter((n) => !autoActivatedAliases.has(n));
 
 		// Build result: non-alias tools + preserved user aliases + desired aliases
-		const nonAlias = activeNames.filter((n) => !registeredMcpAliases.has(n));
+		const nonAlias = activeNames.filter((n) => !registeredMcpAliases.has(lower(n)));
 		const next = Array.from(new Set([...nonAlias, ...preserved, ...desiredAliases]));
 
 		// Update auto-activation tracking: aliases we added this sync that weren't user-preserved

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -15,10 +15,12 @@ import * as typeboxValueModule from "typebox/value";
 // Types
 // ============================================================================
 
+type ToolAliasPair = readonly [flatName: string, mcpName: string];
+
 interface CompanionSpec {
 	dirName: string;
 	packageName: string;
-	aliases: ReadonlyArray<readonly [flatName: string, mcpName: string]>;
+	aliases: ReadonlyArray<ToolAliasPair>;
 }
 
 type ToolRegistration = Parameters<ExtensionAPI["registerTool"]>[0];
@@ -53,18 +55,6 @@ const CORE_TOOL_NAMES = new Set([
 	"websearch",
 ]);
 
-/** Built-in flat companion tool name → MCP-style alias entries. */
-const BUILTIN_FLAT_TO_MCP_ENTRIES = [
-	["web_search_exa", "mcp__exa__web_search"],
-	["get_code_context_exa", "mcp__exa__get_code_context"],
-	["firecrawl_scrape", "mcp__firecrawl__scrape"],
-	["firecrawl_map", "mcp__firecrawl__map"],
-	["firecrawl_search", "mcp__firecrawl__search"],
-] as const;
-
-/** Flat tool name → MCP-style alias. Rebuilt from built-ins plus current user config. */
-const FLAT_TO_MCP = new Map<string, string>(BUILTIN_FLAT_TO_MCP_ENTRIES);
-
 /** Known companion extensions and the tools they provide. */
 const COMPANIONS: CompanionSpec[] = [
 	{
@@ -86,6 +76,12 @@ const COMPANIONS: CompanionSpec[] = [
 	},
 ];
 
+/** Built-in flat companion tool name → MCP-style alias entries, derived from companion metadata. */
+const COMPANION_ALIAS_ENTRIES: ReadonlyArray<ToolAliasPair> = COMPANIONS.flatMap((spec) => spec.aliases);
+
+/** Flat tool name → MCP-style alias. Rebuilt from built-in companions plus current user config. */
+const FLAT_TO_MCP = new Map<string, string>(COMPANION_ALIAS_ENTRIES);
+
 /** Reverse lookup: flat tool name → its companion spec. */
 const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
 	COMPANIONS.flatMap((spec) => spec.aliases.map(([flat]) => [flat, spec] as const)),
@@ -103,8 +99,6 @@ const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
 // ============================================================================
 
 const CONFIG_FILENAME = "pi-claude-code-use.json";
-
-type ToolAliasPair = readonly [flatName: string, mcpName: string];
 
 function readConfigFile(filePath: string): Record<string, unknown> {
 	if (!existsSync(filePath)) return {};
@@ -155,7 +149,7 @@ function lower(name: string | undefined): string {
 function refreshAliasMap(userToolAliases: ToolAliasPair[]): void {
 	FLAT_TO_MCP.clear();
 	MCP_TO_FLAT.clear();
-	for (const [flat, mcp] of BUILTIN_FLAT_TO_MCP_ENTRIES) {
+	for (const [flat, mcp] of COMPANION_ALIAS_ENTRIES) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
 		MCP_TO_FLAT.set(lower(mcp), flat);
 	}
@@ -168,7 +162,7 @@ function refreshAliasMap(userToolAliases: ToolAliasPair[]): void {
 // Reverse map: MCP-prefixed alias (lowercase) → canonical flat name.
 // Populated alongside FLAT_TO_MCP. Used by `unaliasToolCalls`.
 const MCP_TO_FLAT = new Map<string, string>();
-for (const [flat, mcp] of BUILTIN_FLAT_TO_MCP_ENTRIES) {
+for (const [flat, mcp] of COMPANION_ALIAS_ENTRIES) {
 	MCP_TO_FLAT.set(lower(mcp), flat);
 }
 
@@ -437,8 +431,9 @@ function writeDebugLog(payload: unknown): void {
 // Companion alias registration (PRD §1.3)
 //
 // Discovers loaded companion extensions, captures their tool definitions via
-// a shim ExtensionAPI, and registers MCP-alias versions so the model can
-// invoke them under Claude Code-compatible names.
+// a shim ExtensionAPI, and registers MCP-alias versions so Anthropic sees
+// Claude Code-compatible tool names. Managed alias tool calls are rewritten
+// back to their flat source names at `message_end` before Pi resolves execution.
 // ============================================================================
 
 const registeredMcpAliases = new Set<string>();

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-claude-code-use",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
   "keywords": [
     "pi",


### PR DESCRIPTION
- Rewrite MCP-aliased toolCall names back to flat canonical names before the agent loop resolves tools, so Pi invokes the original extension's execute instead of a jiti-loaded duplicate.
- Maintain a reverse MCP_TO_FLAT map alongside FLAT_TO_MCP and factor shared block-name remapping into remapBlockNames.
- Add unit tests covering unaliasToolCalls and the message_end wiring.