### PR TITLE
fix(pi-synthetic-provider): register live startup models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4733,7 +4733,7 @@
     },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.77.0"

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.15] - 2026-06-18
+
 ### Fixed
+- Fetch and register Synthetic models during extension startup so saved defaults and enabled/scoped Synthetic models are available before pi resolves the startup model.
 - Added a three-second timeout for Synthetic model catalog fetches and fall back to hardcoded models when the live catalog is unavailable or filters to no supported models.
 
 ### Changed
+- Kept the session-start model refresh path aligned with startup registration by re-registering the provider with either live models or fallback models.
 - Refreshed the hardcoded Synthetic fallback catalog from the authenticated `/openai/v1/models` endpoint.
 
 ## [1.1.14] - 2026-06-08

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added a three-second timeout for Synthetic model catalog fetches and fall back to hardcoded models when the live catalog is unavailable or filters to no supported models.
+
+### Changed
+- Refreshed the hardcoded Synthetic fallback catalog from the authenticated `/openai/v1/models` endpoint.
+
 ## [1.1.14] - 2026-06-08
 
 ### Fixed

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -72,14 +72,24 @@ pi --provider synthetic --model hf:moonshotai/Kimi-K2.6
 
 ## Available Models
 
-Models are fetched at startup from the [Synthetic models endpoint](https://dev.synthetic.new/docs/api/models). If the API is unreachable, the provider falls back to the following hardcoded defaults:
+Models are fetched at startup from the [Synthetic models endpoint](https://dev.synthetic.new/docs/api/models). If the startup fetch fails, times out after three seconds, or returns no supported models, the provider falls back to the following hardcoded defaults:
 
 | Model | ID | Reasoning | Vision | Context | Max Output |
 |-------|-----|-----------|--------|---------|------------|
-| **Kimi K2.6** | `hf:moonshotai/Kimi-K2.6` | Yes | Yes | 262K | 65K |
-| **MiniMax M2.5** | `hf:MiniMaxAI/MiniMax-M2.5` | Yes | No | 191K | 65K |
-| **Nemotron 3 Super 120B** | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | Yes | No | 262K | 65K |
+| **Synthetic Large Text** | `syn:large:text` | Yes | No | 524K | 65K |
+| **Synthetic Small Text** | `syn:small:text` | Yes | No | 196K | 65K |
+| **Synthetic Large Vision** | `syn:large:vision` | Yes | Yes | 262K | 65K |
+| **Synthetic Small Vision** | `syn:small:vision` | Yes | Yes | 262K | 65K |
+| **GLM 5.2** | `hf:zai-org/GLM-5.2` | Yes | No | 524K | 65K |
 | **GLM 5.1** | `hf:zai-org/GLM-5.1` | Yes | No | 196K | 65K |
+| **Kimi K2.6** | `hf:moonshotai/Kimi-K2.6` | Yes | Yes | 262K | 65K |
+| **Qwen 3.6 27B** | `hf:Qwen/Qwen3.6-27B` | Yes | Yes | 262K | 65K |
+| **MiniMax M3** | `hf:MiniMaxAI/MiniMax-M3` | Yes | Yes | 524K | 65K |
+| **GLM 4.7 Flash** | `hf:zai-org/GLM-4.7-Flash` | Yes | No | 196K | 65K |
+| **Nemotron 3 Super 120B** | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | Yes | No | 262K | 65K |
+| **GLM 4.7** | `hf:zai-org/GLM-4.7` | Yes | No | 203K | 65K |
+| **GPT OSS 120B** | `hf:openai/gpt-oss-120b` | No | No | 131K | 32K |
+| **Qwen 3.5 397B A17B** | `hf:Qwen/Qwen3.5-397B-A17B` | No | Yes | 262K | 32K |
 
 Run `/synthetic-models` inside pi for the live catalog.
 

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -19,11 +19,15 @@ describe("pi-synthetic-provider helpers", () => {
 
 	it("provides fallback models", () => {
 		const models = getFallbackModels();
-		expect(models.length).toBeGreaterThan(0);
+		expect(models).toHaveLength(14);
+		expect(models.some((model) => model.id === "syn:large:text")).toBe(true);
+		expect(models.some((model) => model.id === "syn:small:vision")).toBe(true);
+		expect(models.some((model) => model.id === "hf:zai-org/GLM-5.2")).toBe(true);
 		expect(models.some((model) => model.id === "hf:moonshotai/Kimi-K2.6")).toBe(true);
 		expect(models.some((model) => model.id === "hf:nvidia/Kimi-K2.5-NVFP4")).toBe(false);
 		expect(models.some((model) => model.id === "hf:nvidia/Kimi-K2.6-NVFP4")).toBe(false);
-		expect(models.some((model) => model.id === "hf:MiniMaxAI/MiniMax-M2.5")).toBe(true);
+		expect(models.some((model) => model.id === "hf:MiniMaxAI/MiniMax-M2.5")).toBe(false);
+		expect(models.some((model) => model.id === "hf:MiniMaxAI/MiniMax-M3")).toBe(true);
 		expect(models.some((model) => model.id === "hf:zai-org/GLM-5.1")).toBe(true);
 		expect(models.some((model) => model.id === "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4")).toBe(true);
 		for (const model of models) {

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import syntheticProvider from "../extensions/index.js";
 
 const createMockPi = () =>
@@ -9,14 +9,49 @@ const createMockPi = () =>
 		on: vi.fn(),
 	}) satisfies Partial<ExtensionAPI>;
 
+const stubModelsFetch = () => {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				data: [
+					{
+						id: "hf:zai-org/GLM-5.2",
+						name: "zai-org/GLM-5.2",
+						always_on: true,
+						supported_features: ["tools", "reasoning"],
+						input_modalities: ["text"],
+						context_length: 524288,
+						max_output_length: 65536,
+						pricing: {
+							prompt: "1",
+							completion: "3",
+						},
+					},
+				],
+			}),
+		}),
+	);
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
 describe("pi-synthetic-provider", () => {
-	it("registers provider and commands", () => {
+	it("registers live startup provider and commands", async () => {
+		stubModelsFetch();
 		const mockPi = createMockPi();
-		syntheticProvider(mockPi as unknown as ExtensionAPI);
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
 
 		expect(mockPi.registerProvider).toHaveBeenCalledWith(
 			"synthetic",
-			expect.objectContaining({ api: "openai-completions", apiKey: "$SYNTHETIC_API_KEY" }),
+			expect.objectContaining({
+				api: "openai-completions",
+				apiKey: "$SYNTHETIC_API_KEY",
+				models: [expect.objectContaining({ id: "hf:zai-org/GLM-5.2" })],
+			}),
 		);
 		expect(mockPi.registerCommand).toHaveBeenCalledWith(
 			"synthetic-models",
@@ -28,9 +63,10 @@ describe("pi-synthetic-provider", () => {
 		);
 	});
 
-	it("registers event listeners", () => {
+	it("registers event listeners", async () => {
+		stubModelsFetch();
 		const mockPi = createMockPi();
-		syntheticProvider(mockPi as unknown as ExtensionAPI);
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
 
 		const eventNames = mockPi.on.mock.calls.map(([name]) => name);
 		expect(eventNames).toEqual(expect.arrayContaining(["session_start", "model_select"]));

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -1,6 +1,6 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import syntheticProvider from "../extensions/index.js";
+import syntheticProvider, { getFallbackModels } from "../extensions/index.js";
 
 const createMockPi = () =>
 	({
@@ -36,7 +36,9 @@ const stubModelsFetch = () => {
 };
 
 afterEach(() => {
+	vi.useRealTimers();
 	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
 });
 
 describe("pi-synthetic-provider", () => {
@@ -70,5 +72,38 @@ describe("pi-synthetic-provider", () => {
 
 		const eventNames = mockPi.on.mock.calls.map(([name]) => name);
 		expect(eventNames).toEqual(expect.arrayContaining(["session_start", "model_select"]));
+	});
+
+	it("uses fallback startup models when the live catalog filters to empty", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ data: [{ id: "off-model", always_on: false }] }),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		expect(models).toEqual(getFallbackModels());
+		expect(models.some((model) => model.id === "off-model")).toBe(false);
+	});
+
+	it("uses fallback startup models when the live fetch times out", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => new Promise(() => {})),
+		);
+		const mockPi = createMockPi();
+		const init = syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		await vi.advanceTimersByTimeAsync(3000);
+		await init;
+
+		expect(mockPi.registerProvider.mock.calls[0]?.[1].models).toEqual(getFallbackModels());
 	});
 });

--- a/packages/pi-synthetic-provider/extensions/config.ts
+++ b/packages/pi-synthetic-provider/extensions/config.ts
@@ -5,6 +5,7 @@
 
 export const SYNTHETIC_API_BASE_URL = "https://api.synthetic.new/openai/v1";
 export const SYNTHETIC_MODELS_ENDPOINT = `${SYNTHETIC_API_BASE_URL}/models`;
+export const SYNTHETIC_MODELS_FETCH_TIMEOUT_MS = 3000;
 export const SYNTHETIC_QUOTAS_ENDPOINT = "https://api.synthetic.new/v2/quotas";
 
 /** Shared compat flags for all Synthetic models (OpenAI-compatible API). */

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -70,8 +70,11 @@ export {
 	shouldDisplaySubscriptionQuota,
 } from "./quota.js";
 
-export default function (pi: ExtensionAPI) {
-	// Register provider synchronously with fallback models.
+export default async function (pi: ExtensionAPI) {
+	const startupModels = await fetchSyntheticModels();
+
+	// Register provider during extension loading with live models, falling back
+	// inside fetchSyntheticModels() if the API is unavailable.
 	// pi.registerProvider() during loading is queued and applied during
 	// runner.initialize(). Registrations in event handlers (e.g., session_start)
 	// are queued but never flushed, so the initial registration must happen here.
@@ -79,7 +82,7 @@ export default function (pi: ExtensionAPI) {
 		baseUrl: SYNTHETIC_API_BASE_URL,
 		apiKey: "$SYNTHETIC_API_KEY",
 		api: "openai-completions",
-		models: getFallbackModels(),
+		models: startupModels,
 	});
 
 	// After session starts, replace fallback models with live data from the API.

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -85,7 +85,7 @@ export default async function (pi: ExtensionAPI) {
 		models: startupModels,
 	});
 
-	// After session starts, replace fallback models with live data from the API.
+	// After session starts, refresh models from the API and update the runtime provider registration.
 	// pi.registerProvider() now takes effect immediately after startup and also
 	// lets the runtime refresh the current model reference if the provider config
 	// changes beneath an already-selected model.

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -37,24 +37,18 @@
  *   # Use default model
  *   pi --provider synthetic --model hf:moonshotai/Kimi-K2.6
  *
- * Supported Models (as of 2026-05-01):
- * - hf:moonshotai/Kimi-K2.6 (reasoning + vision)
- * - hf:MiniMaxAI/MiniMax-M2.5 (reasoning)
- * - hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (reasoning)
- * - hf:zai-org/GLM-5.1 (reasoning)
- *
- * Note: Models are fetched dynamically from the API at session start, so the
- * available models list is always current.
+ * Note: Models are fetched dynamically from the API during startup and refreshed
+ * at session start, so the available models list stays current.
  *
  * Developer Note: To update fallback pricing, run:
- *   curl -s https://api.synthetic.new/openai/v1/models | jq '.data[] | select(.always_on == true) | {id, name, provider, context_length, max_output_length, pricing}'
+ *   curl -s https://api.synthetic.new/openai/v1/models | jq '.data[] | select(.always_on == true)'
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getSyntheticApiKey, hasSyntheticApiKey } from "./auth.js";
 import { registerSyntheticModelsCommand } from "./commands/synthetic-models.js";
 import { registerSyntheticQuotaCommand } from "./commands/synthetic-quota.js";
-import { AUTH_JSON_PATH, SYNTHETIC_API_BASE_URL } from "./config.js";
+import { AUTH_JSON_PATH, SYNTHETIC_API_BASE_URL, SYNTHETIC_MODELS_FETCH_TIMEOUT_MS } from "./config.js";
 import { fetchSyntheticModels } from "./models.js";
 
 // Re-export public API for tests and consumers
@@ -71,10 +65,10 @@ export {
 } from "./quota.js";
 
 export default async function (pi: ExtensionAPI) {
-	const startupModels = await fetchSyntheticModels();
+	const startupModels = await fetchSyntheticModels(undefined, { timeoutMs: SYNTHETIC_MODELS_FETCH_TIMEOUT_MS });
 
 	// Register provider during extension loading with live models, falling back
-	// inside fetchSyntheticModels() if the API is unavailable.
+	// inside fetchSyntheticModels() if the API is unavailable, slow, or empty.
 	// pi.registerProvider() during loading is queued and applied during
 	// runner.initialize(). Registrations in event handlers (e.g., session_start)
 	// are queued but never flushed, so the initial registration must happen here.
@@ -100,19 +94,17 @@ export default async function (pi: ExtensionAPI) {
 			console.log(`  2. Add to ${AUTH_JSON_PATH} (see README for details)`);
 		}
 
-		// Fetch live models and update the runtime provider registration
-		const models = await fetchSyntheticModels(apiKey);
+		// Fetch live models and update the runtime provider registration.
+		// fetchSyntheticModels() returns fallback models if the API is unavailable,
+		// slow, or returns no supported models.
+		const models = await fetchSyntheticModels(apiKey, { timeoutMs: SYNTHETIC_MODELS_FETCH_TIMEOUT_MS });
 
-		if (models.length > 0) {
-			pi.registerProvider("synthetic", {
-				baseUrl: SYNTHETIC_API_BASE_URL,
-				apiKey: "$SYNTHETIC_API_KEY",
-				api: "openai-completions",
-				models,
-			});
-		} else {
-			console.log("[Synthetic Provider] API unavailable, using fallback models");
-		}
+		pi.registerProvider("synthetic", {
+			baseUrl: SYNTHETIC_API_BASE_URL,
+			apiKey: "$SYNTHETIC_API_KEY",
+			api: "openai-completions",
+			models,
+		});
 	});
 
 	// Listen for model selection to provide helpful info

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -55,7 +55,7 @@ import { getSyntheticApiKey, hasSyntheticApiKey } from "./auth.js";
 import { registerSyntheticModelsCommand } from "./commands/synthetic-models.js";
 import { registerSyntheticQuotaCommand } from "./commands/synthetic-quota.js";
 import { AUTH_JSON_PATH, SYNTHETIC_API_BASE_URL } from "./config.js";
-import { fetchSyntheticModels, getFallbackModels } from "./models.js";
+import { fetchSyntheticModels } from "./models.js";
 
 // Re-export public API for tests and consumers
 export { parsePrice } from "./formatting.js";

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -7,10 +7,41 @@ import { SYNTHETIC_COMPAT, SYNTHETIC_MODELS_ENDPOINT } from "./config.js";
 import { parsePrice } from "./formatting.js";
 import type { SyntheticModelsResponse } from "./types.js";
 
+export interface FetchSyntheticModelsOptions {
+	timeoutMs?: number;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs?: number): Promise<Response> {
+	if (timeoutMs === undefined) {
+		return fetch(url, init);
+	}
+
+	const controller = new AbortController();
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	const timeout = new Promise<never>((_, reject) => {
+		timeoutId = setTimeout(() => {
+			controller.abort();
+			reject(new Error(`Timed out fetching Synthetic models after ${timeoutMs}ms`));
+		}, timeoutMs);
+	});
+
+	try {
+		return await Promise.race([fetch(url, { ...init, signal: controller.signal }), timeout]);
+	} finally {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId);
+		}
+	}
+}
+
 /**
  * Fetch models from Synthetic API and transform to ProviderModelConfig format.
  */
-export async function fetchSyntheticModels(apiKey?: string): Promise<ProviderModelConfig[]> {
+export async function fetchSyntheticModels(
+	apiKey?: string,
+	options: FetchSyntheticModelsOptions = {},
+): Promise<ProviderModelConfig[]> {
 	try {
 		const headers: Record<string, string> = {
 			Accept: "application/json",
@@ -21,7 +52,7 @@ export async function fetchSyntheticModels(apiKey?: string): Promise<ProviderMod
 			headers.Authorization = `Bearer ${apiKey}`;
 		}
 
-		const response = await fetch(SYNTHETIC_MODELS_ENDPOINT, { headers });
+		const response = await fetchWithTimeout(SYNTHETIC_MODELS_ENDPOINT, { headers }, options.timeoutMs);
 
 		if (!response.ok) {
 			const errorText = await response.text();
@@ -67,6 +98,11 @@ export async function fetchSyntheticModels(apiKey?: string): Promise<ProviderMod
 			});
 		}
 
+		if (models.length === 0) {
+			console.warn("[Synthetic Provider] Live model catalog returned no supported models; using fallback models");
+			return getFallbackModels();
+		}
+
 		return models;
 	} catch (error) {
 		console.error("[Synthetic Provider] Failed to fetch models:", error);
@@ -77,18 +113,103 @@ export async function fetchSyntheticModels(apiKey?: string): Promise<ProviderMod
 
 /**
  * Fallback models if API fetch fails.
- * Data sourced from: curl https://api.synthetic.new/openai/v1/models
- * Last updated: 2026-05-01
+ * Data sourced from: authenticated GET https://api.synthetic.new/openai/v1/models
+ * Last updated: 2026-06-18
  *
  * Pricing format: $/million tokens
- * Synthetic-hosted models:
- * - Kimi-K2.6: $0.95 input, $4.00 output, 262K context
- * - MiniMax-M2.5: $0.40 input, $2.00 output, 191K context
- * - Nemotron-3-Super-120B-A12B-NVFP4: $0.30 input, $1.00 output, 262K context
- * - GLM-5.1: $1.00 input, $3.00 output, 196K context
  */
 export function getFallbackModels(): ProviderModelConfig[] {
 	return [
+		{
+			id: "syn:large:text",
+			name: "syn:large:text",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1.4,
+				output: 4.4,
+				cacheRead: 1.4,
+				cacheWrite: 0,
+			},
+			contextWindow: 524288,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "syn:small:text",
+			name: "syn:small:text",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.1,
+				output: 0.5,
+				cacheRead: 0.1,
+				cacheWrite: 0,
+			},
+			contextWindow: 196608,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "syn:large:vision",
+			name: "syn:large:vision",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0.95,
+				output: 4,
+				cacheRead: 0.95,
+				cacheWrite: 0,
+			},
+			contextWindow: 262144,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "syn:small:vision",
+			name: "syn:small:vision",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0.45,
+				output: 3.6,
+				cacheRead: 0.45,
+				cacheWrite: 0,
+			},
+			contextWindow: 262144,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:zai-org/GLM-5.2",
+			name: "zai-org/GLM-5.2",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1.4,
+				output: 4.4,
+				cacheRead: 1.4,
+				cacheWrite: 0,
+			},
+			contextWindow: 524288,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:zai-org/GLM-5.1",
+			name: "zai-org/GLM-5.1",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 1,
+				output: 3,
+				cacheRead: 1,
+				cacheWrite: 0,
+			},
+			contextWindow: 196608,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
 		{
 			id: "hf:moonshotai/Kimi-K2.6",
 			name: "moonshotai/Kimi-K2.6",
@@ -105,17 +226,47 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			compat: SYNTHETIC_COMPAT,
 		},
 		{
-			id: "hf:MiniMaxAI/MiniMax-M2.5",
-			name: "MiniMaxAI/MiniMax-M2.5",
+			id: "hf:Qwen/Qwen3.6-27B",
+			name: "Qwen/Qwen3.6-27B",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0.45,
+				output: 3.6,
+				cacheRead: 0.45,
+				cacheWrite: 0,
+			},
+			contextWindow: 262144,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:MiniMaxAI/MiniMax-M3",
+			name: "MiniMaxAI/MiniMax-M3",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0.6,
+				output: 1.2,
+				cacheRead: 0.6,
+				cacheWrite: 0,
+			},
+			contextWindow: 524288,
+			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:zai-org/GLM-4.7-Flash",
+			name: "zai-org/GLM-4.7-Flash",
 			reasoning: true,
 			input: ["text"],
 			cost: {
-				input: 0.4,
-				output: 2,
-				cacheRead: 0.4,
+				input: 0.1,
+				output: 0.5,
+				cacheRead: 0.1,
 				cacheWrite: 0,
 			},
-			contextWindow: 191488,
+			contextWindow: 196608,
 			maxTokens: 65536,
 			compat: SYNTHETIC_COMPAT,
 		},
@@ -135,18 +286,48 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			compat: SYNTHETIC_COMPAT,
 		},
 		{
-			id: "hf:zai-org/GLM-5.1",
-			name: "zai-org/GLM-5.1",
+			id: "hf:zai-org/GLM-4.7",
+			name: "zai-org/GLM-4.7",
 			reasoning: true,
 			input: ["text"],
 			cost: {
-				input: 1,
-				output: 3,
-				cacheRead: 1,
+				input: 0.45,
+				output: 2.19,
+				cacheRead: 0.45,
 				cacheWrite: 0,
 			},
-			contextWindow: 196608,
+			contextWindow: 202752,
 			maxTokens: 65536,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:openai/gpt-oss-120b",
+			name: "openai/gpt-oss-120b",
+			reasoning: false,
+			input: ["text"],
+			cost: {
+				input: 0.1,
+				output: 0.1,
+				cacheRead: 0.1,
+				cacheWrite: 0,
+			},
+			contextWindow: 131072,
+			maxTokens: 32768,
+			compat: SYNTHETIC_COMPAT,
+		},
+		{
+			id: "hf:Qwen/Qwen3.5-397B-A17B",
+			name: "Qwen/Qwen3.5-397B-A17B",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: {
+				input: 0.6,
+				output: 3.6,
+				cacheRead: 0.6,
+				cacheWrite: 0,
+			},
+			contextWindow: 262144,
+			maxTokens: 32768,
 			compat: SYNTHETIC_COMPAT,
 		},
 	];

--- a/packages/pi-synthetic-provider/package.json
+++ b/packages/pi-synthetic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-synthetic-provider",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Synthetic (synthetic.new) model provider for pi - Dynamic model fetching with reasoning, vision, and tools support",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

- Fetch live Synthetic models during extension loading before initial provider registration.
- Preserve existing fallback behavior through `fetchSyntheticModels()` when the models endpoint is unavailable.
- Update startup registration tests to cover a live model that is absent from the stale fallback catalog.

## Verification

- `npm --prefix /var/home/user/pi-packages run test`
- `npm --prefix /var/home/user/pi-packages run check`
- `PI_CODING_AGENT_DIR=<scratch> SYNTHETIC_API_KEY=dummy pi --list-models GLM-5.2` lists `synthetic/hf:zai-org/GLM-5.2` without the startup warning.

## Context

Pi resolves `enabledModels` before the provider's `session_start` refresh is visible. When `enabledModels` contains `synthetic/hf:zai-org/GLM-5.2`, the published fallback catalog only exposes GLM-5.1 at startup, so Pi warns even though GLM-5.2 is present in Synthetic's live models endpoint.
