### PR TITLE
feat(pi-synthetic-provider): support thinking levels for GLM-5.2 via reasoning_effort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4733,7 +4733,7 @@
     },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.77.0"

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.16] - 2026-07-02
 
 ### Added
-- Thinking-level support for `hf:zai-org/GLM-5.2` ([#21](https://github.com/ben-vargas/pi-packages/issues/21)): pi's thinking levels now map onto GLM's supported `reasoning_effort` values (`low`/`medium`/`high` → `high`, `xhigh` → `max`; `minimal` is hidden, and `off` sends no field so the model uses its server-side default). Applied on both the live-catalog and fallback registration paths via a new per-model compat override; all other Synthetic models keep the shared compat until their native thinking parameters are verified through Synthetic's proxy.
+- Thinking-level support for `hf:zai-org/GLM-5.2` ([#21](https://github.com/ben-vargas/pi-packages/issues/21)): pi's thinking levels now map onto GLM's supported `reasoning_effort` values (`low`/`medium`/`high` → `high`, `xhigh` → `max`). `off` and `minimal` are hidden — Synthetic has no documented way to disable GLM reasoning, and omitting the field would silently run at GLM's `max` default, so the lightest selectable level is `low` (sends `high`). Applied on both the live-catalog and fallback registration paths via a new per-model compat override; all other Synthetic models keep the shared compat until their native thinking parameters are verified through Synthetic's proxy.
 
 ## [1.1.15] - 2026-06-18
 

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.16] - 2026-07-02
 
 ### Added
-- Thinking-level support for `hf:zai-org/GLM-5.2` ([#21](https://github.com/ben-vargas/pi-packages/issues/21)): pi's thinking levels now map onto GLM's supported `reasoning_effort` values (`low`/`medium`/`high` → `high`, `xhigh` → `max`). `off` and `minimal` are hidden — Synthetic has no documented way to disable GLM reasoning, and omitting the field would silently run at GLM's `max` default, so the lightest selectable level is `low` (sends `high`). Applied on both the live-catalog and fallback registration paths via a new per-model compat override; all other Synthetic models keep the shared compat until their native thinking parameters are verified through Synthetic's proxy.
+- Thinking-level support for `hf:zai-org/GLM-5.2` ([#21](https://github.com/ben-vargas/pi-packages/issues/21)): pi's thinking levels now map onto GLM's supported `reasoning_effort` values (`low`/`medium`/`high` → `high`, `xhigh` → `max`). `off` and `minimal` are hidden — Synthetic has no documented way to disable GLM reasoning, and omitting the field would silently run at GLM's `max` default, so the lightest selectable level is `low` (sends `high`). Applied on both the live-catalog and fallback registration paths via a new per-model compat override, which also pins `reasoning: true` so a live catalog row missing `supported_features` cannot silently disable the effort mapping; all other Synthetic models keep the shared compat until their native thinking parameters are verified through Synthetic's proxy.
 
 ## [1.1.15] - 2026-06-18
 

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.16] - 2026-07-02
+
+### Added
+- Thinking-level support for `hf:zai-org/GLM-5.2` ([#21](https://github.com/ben-vargas/pi-packages/issues/21)): pi's thinking levels now map onto GLM's supported `reasoning_effort` values (`low`/`medium`/`high` → `high`, `xhigh` → `max`; `minimal` is hidden, and `off` sends no field so the model uses its server-side default). Applied on both the live-catalog and fallback registration paths via a new per-model compat override; all other Synthetic models keep the shared compat until their native thinking parameters are verified through Synthetic's proxy.
+
 ## [1.1.15] - 2026-06-18
 
 ### Fixed

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -35,6 +35,25 @@ describe("pi-synthetic-provider helpers", () => {
 			expect(model.name).toEqual(expect.any(String));
 		}
 	});
+
+	it("enables reasoning effort only for GLM-5.2 in fallback models", () => {
+		const models = getFallbackModels();
+		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
+		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
+		expect(glm?.thinkingLevelMap).toEqual({
+			minimal: null,
+			low: "high",
+			medium: "high",
+			high: "high",
+			xhigh: "max",
+		});
+
+		for (const model of models) {
+			if (model.id === "hf:zai-org/GLM-5.2") continue;
+			expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
+			expect(model.thinkingLevelMap).toBeUndefined();
+		}
+	});
 });
 
 describe("quota helpers", () => {

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -41,6 +41,7 @@ describe("pi-synthetic-provider helpers", () => {
 		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
 		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
 		expect(glm?.thinkingLevelMap).toEqual({
+			off: null,
 			minimal: null,
 			low: "high",
 			medium: "high",

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -95,6 +95,7 @@ describe("pi-synthetic-provider", () => {
 		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
 		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
 		expect(glm?.thinkingLevelMap).toEqual({
+			off: null,
 			minimal: null,
 			low: "high",
 			medium: "high",

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -65,6 +65,48 @@ describe("pi-synthetic-provider", () => {
 		);
 	});
 
+	it("applies GLM-5.2 reasoning-effort overrides to live models only", async () => {
+		const liveModel = (id: string, name: string) => ({
+			id,
+			name,
+			always_on: true,
+			supported_features: ["tools", "reasoning"],
+			input_modalities: ["text"],
+			context_length: 524288,
+			max_output_length: 65536,
+			pricing: { prompt: "1", completion: "3" },
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: [
+						liveModel("hf:zai-org/GLM-5.2", "zai-org/GLM-5.2"),
+						liveModel("hf:MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M3"),
+					],
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
+		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
+		expect(glm?.thinkingLevelMap).toEqual({
+			minimal: null,
+			low: "high",
+			medium: "high",
+			high: "high",
+			xhigh: "max",
+		});
+
+		const minimax = models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3");
+		expect(minimax).toMatchObject({ compat: { supportsReasoningEffort: false } });
+		expect(minimax?.thinkingLevelMap).toBeUndefined();
+	});
+
 	it("registers event listeners", async () => {
 		stubModelsFetch();
 		const mockPi = createMockPi();

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -108,6 +108,39 @@ describe("pi-synthetic-provider", () => {
 		expect(minimax?.thinkingLevelMap).toBeUndefined();
 	});
 
+	it("keeps GLM-5.2 reasoning enabled when the live catalog omits supported_features", async () => {
+		const liveModel = (id: string, name: string) => ({
+			id,
+			name,
+			always_on: true,
+			input_modalities: ["text"],
+			context_length: 524288,
+			max_output_length: 65536,
+			pricing: { prompt: "1", completion: "3" },
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: [
+						liveModel("hf:zai-org/GLM-5.2", "zai-org/GLM-5.2"),
+						liveModel("hf:MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M3"),
+					],
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
+		expect(glm).toMatchObject({ reasoning: true, compat: { supportsReasoningEffort: true } });
+
+		const minimax = models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3");
+		expect(minimax).toMatchObject({ reasoning: false });
+	});
+
 	it("registers event listeners", async () => {
 		stubModelsFetch();
 		const mockPi = createMockPi();

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -7,6 +7,43 @@ import { SYNTHETIC_COMPAT, SYNTHETIC_MODELS_ENDPOINT } from "./config.js";
 import { parsePrice } from "./formatting.js";
 import type { SyntheticModelsResponse } from "./types.js";
 
+export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
+
+/**
+ * Per-model reasoning-effort support (https://github.com/ben-vargas/pi-packages/issues/21).
+ *
+ * GLM-5.2 accepts `reasoning_effort` with two values, "high" and "max" (its
+ * server-side default is "max" when the field is omitted, so "off" sends
+ * nothing). The map mirrors pi's built-in zai/glm-5.2 model, except we stay on
+ * the adapter's default OpenAI thinking format: Synthetic's proxy documents
+ * `reasoning_effort` only, not z.ai's `thinking: { type }` object.
+ *
+ * `minimal: null` hides that level from pi's thinking-level cycling — GLM has
+ * no setting lighter than "high". Other catalog models keep the shared compat
+ * (no effort field sent) until their native thinking parameters are verified
+ * through Synthetic; an unsupported parameter fails the request with no retry.
+ */
+const GLM_5_2_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+	},
+	thinkingLevelMap: {
+		minimal: null,
+		low: "high",
+		medium: "high",
+		high: "high",
+		xhigh: "max",
+	},
+} satisfies Pick<ProviderModelConfig, "compat" | "thinkingLevelMap">;
+
+export function getSyntheticModelOverrides(modelId: string): Pick<ProviderModelConfig, "compat" | "thinkingLevelMap"> {
+	if (modelId === GLM_5_2_MODEL_ID) {
+		return GLM_5_2_REASONING_OVERRIDES;
+	}
+	return { compat: SYNTHETIC_COMPAT };
+}
+
 export interface FetchSyntheticModelsOptions {
 	timeoutMs?: number;
 }
@@ -94,7 +131,7 @@ export async function fetchSyntheticModels(
 				},
 				contextWindow: model.context_length || 128000,
 				maxTokens: model.max_output_length || 32768,
-				compat: SYNTHETIC_COMPAT,
+				...getSyntheticModelOverrides(modelId),
 			});
 		}
 
@@ -181,7 +218,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			compat: SYNTHETIC_COMPAT,
 		},
 		{
-			id: "hf:zai-org/GLM-5.2",
+			id: GLM_5_2_MODEL_ID,
 			name: "zai-org/GLM-5.2",
 			reasoning: true,
 			input: ["text"],
@@ -193,7 +230,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 524288,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(GLM_5_2_MODEL_ID),
 		},
 		{
 			id: "hf:zai-org/GLM-5.1",

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -26,8 +26,15 @@ export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
  * shared compat (no effort field sent) until their native thinking parameters
  * are verified through Synthetic; an unsupported parameter fails the request
  * with no retry.
+ *
+ * `reasoning: true` is pinned because the live catalog only populates
+ * `supported_features` for Synthetic-hosted models and the adapter gates all
+ * effort emission on `model.reasoning`; without the pin, a live GLM-5.2 row
+ * missing that field would register with the override silently inert while
+ * the fallback path works.
  */
 const GLM_5_2_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
@@ -40,9 +47,12 @@ const GLM_5_2_REASONING_OVERRIDES = {
 		high: "high",
 		xhigh: "max",
 	},
-} satisfies Pick<ProviderModelConfig, "compat" | "thinkingLevelMap">;
+} satisfies Pick<ProviderModelConfig, "reasoning" | "compat" | "thinkingLevelMap">;
 
-export function getSyntheticModelOverrides(modelId: string): Pick<ProviderModelConfig, "compat" | "thinkingLevelMap"> {
+type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
+	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
+
+export function getSyntheticModelOverrides(modelId: string): SyntheticModelOverrides {
 	if (modelId === GLM_5_2_MODEL_ID) {
 		return GLM_5_2_REASONING_OVERRIDES;
 	}

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -13,15 +13,19 @@ export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
  * Per-model reasoning-effort support (https://github.com/ben-vargas/pi-packages/issues/21).
  *
  * GLM-5.2 accepts `reasoning_effort` with two values, "high" and "max" (its
- * server-side default is "max" when the field is omitted, so "off" sends
- * nothing). The map mirrors pi's built-in zai/glm-5.2 model, except we stay on
- * the adapter's default OpenAI thinking format: Synthetic's proxy documents
- * `reasoning_effort` only, not z.ai's `thinking: { type }` object.
+ * server-side default is "max" when the field is omitted). The map mirrors
+ * pi's built-in zai/glm-5.2 model, except we stay on the adapter's default
+ * OpenAI thinking format: Synthetic's proxy documents `reasoning_effort`
+ * only, not z.ai's `thinking: { type }` object.
  *
- * `minimal: null` hides that level from pi's thinking-level cycling — GLM has
- * no setting lighter than "high". Other catalog models keep the shared compat
- * (no effort field sent) until their native thinking parameters are verified
- * through Synthetic; an unsupported parameter fails the request with no retry.
+ * `null` hides a level from pi's thinking-level cycling. "off" is hidden
+ * because omitting the field would silently run GLM at its "max" default and
+ * Synthetic has no documented disable parameter; pi clamps "off" to "low",
+ * so the lightest selectable setting sends "high". "minimal" is hidden
+ * because GLM has nothing lighter than "high". Other catalog models keep the
+ * shared compat (no effort field sent) until their native thinking parameters
+ * are verified through Synthetic; an unsupported parameter fails the request
+ * with no retry.
  */
 const GLM_5_2_REASONING_OVERRIDES = {
 	compat: {
@@ -29,6 +33,7 @@ const GLM_5_2_REASONING_OVERRIDES = {
 		supportsReasoningEffort: true,
 	},
 	thinkingLevelMap: {
+		off: null,
 		minimal: null,
 		low: "high",
 		medium: "high",

--- a/packages/pi-synthetic-provider/package.json
+++ b/packages/pi-synthetic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-synthetic-provider",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Synthetic (synthetic.new) model provider for pi - Dynamic model fetching with reasoning, vision, and tools support",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

Closes #21.

pi's thinking-level control (Shift+Tab / `--thinking` / `defaultThinkingLevel`) was a no-op on every Synthetic model: the shared `SYNTHETIC_COMPAT` sets `supportsReasoningEffort: false` with no `thinkingFormat`, so pi's openai-completions adapter never emitted any effort field.

This adds a per-model override in `extensions/models.ts` — applied on **both** the live-fetch path (`fetchSyntheticModels()`, matched by model id) and the static `getFallbackModels()` list — that enables the OpenAI-style `reasoning_effort` path for `hf:zai-org/GLM-5.2`:

```ts
compat: { ...SYNTHETIC_COMPAT, supportsReasoningEffort: true },
thinkingLevelMap: { off: null, minimal: null, low: "high", medium: "high", high: "high", xhigh: "max" }
```

This mirrors pi's built-in `zai/glm-5.2` level map, with two deliberate differences: it stays on the adapter's **default OpenAI thinking format** rather than `thinkingFormat: "zai"` — Synthetic's proxy documents `reasoning_effort` only, not z.ai's `thinking: { type }` object — and it hides `off` (per Codex review feedback): Synthetic has no documented disable parameter, and omitting the field silently runs GLM at its `max` default, so pi clamps `off` to `low` and the lightest effort actually sent is `"high"`. All other catalog models keep the shared compat until their native thinking parameters (Qwen `enable_thinking`, MiniMax `thinking`, Kimi `thinking.enabled/keep`) are verified through Synthetic.

## Validation (live, at the wire)

Drove the real `pi` CLI non-interactively with this extension and a fetch tap capturing outgoing request bodies to `api.synthetic.new/openai/v1/chat/completions`. Every request completed successfully against the live API:

| Run | `reasoning_effort` sent | Result |
| --- | --- | --- |
| GLM-5.2, `--thinking xhigh` | `"max"` | accepted, completion returned |
| GLM-5.2, `--thinking low` | `"high"` | accepted |
| GLM-5.2, `--thinking off` | `"high"` (off hidden, clamped to `low` — no more silent `max` default) | accepted |
| GLM-5.2, `--thinking minimal` (probe) | `"high"` (clamped to `low`; raw `"minimal"` can never leak) | accepted |
| MiniMax-M3, `--thinking xhigh` (control) | *(absent — other models untouched)* | accepted |

No other thinking/reasoning-related keys appeared in any request body.

## Tests

- `__tests__/index.test.ts`: live-catalog registration applies the override to GLM-5.2 and leaves a non-GLM model on shared compat with no `thinkingLevelMap`.
- `__tests__/helpers.test.ts`: fallback list — only GLM-5.2 carries the override; every other model keeps `supportsReasoningEffort: false`.

`npm run check` (biome + tsc) and `vitest run` (46 tests) pass.

## Follow-ups (not in this PR)

- GLM-4.7-Flash reportedly accepts the same `high|max` values — easy follow-up once smoke-tested.
- Qwen3.6 / MiniMax-M3 need live verification of their native formats through Synthetic's proxy; Kimi's `thinking.keep` isn't expressible in pi-ai's current `thinkingFormat` vocabulary.
- `syn:*` aliases are deliberately untouched — their server-side routing can drift under a hardcoded compat.
