### PR TITLE
feat(pi-synthetic-provider): add reasoning_effort support for all models

### DIFF
--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -53,23 +53,39 @@ describe("pi-synthetic-provider helpers", () => {
 		});
 	});
 
-	it("enables reasoning effort only for GLM-5.2 in fallback models", () => {
+	it("enables reasoning effort for all reasoning models in fallback models", () => {
 		const models = getFallbackModels();
+
+		// GLM-5.2
 		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
 		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
 		expect(glm?.thinkingLevelMap).toEqual({
-			off: null,
+			off: "none",
 			minimal: null,
-			low: "high",
-			medium: "high",
+			low: null,
+			medium: null,
 			high: "high",
-			xhigh: "max",
+			xhigh: "medium",
 		});
 
-		for (const model of models) {
-			if (model.id === "hf:zai-org/GLM-5.2") continue;
+		// Other reasoning models should also have effort enabled
+		for (const id of [
+			"hf:zai-org/GLM-4.7-Flash",
+			"hf:moonshotai/Kimi-K2.7-Code",
+			"hf:Qwen/Qwen3.6-27B",
+			"hf:MiniMaxAI/MiniMax-M3",
+			"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+		]) {
+			const model = models.find((m) => m.id === id);
+			expect(model).toMatchObject({ compat: { supportsReasoningEffort: true } });
+			expect(model?.thinkingLevelMap).toBeDefined();
+		}
+
+		// Non-reasoning fallbacks keep default compat
+		for (const id of ["syn:large:text", "syn:small:text", "syn:large:vision", "syn:small:vision", "hf:openai/gpt-oss-120b"]) {
+			const model = models.find((m) => m.id === id);
 			expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
-			expect(model.thinkingLevelMap).toBeUndefined();
+			expect(model?.thinkingLevelMap).toBeUndefined();
 		}
 	});
 });

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -55,34 +55,38 @@ describe("pi-synthetic-provider helpers", () => {
 
 	it("enables reasoning effort for all reasoning models in fallback models", () => {
 		const models = getFallbackModels();
+		const reasoningModels = [
+			["hf:zai-org/GLM-5.2", { off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" }],
+			[
+				"hf:zai-org/GLM-4.7-Flash",
+				{ off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: null },
+			],
+			[
+				"hf:moonshotai/Kimi-K2.7-Code",
+				{ off: null, minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" },
+			],
+			["hf:Qwen/Qwen3.6-27B", { off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" }],
+			["hf:MiniMaxAI/MiniMax-M3", { off: null, minimal: null, low: null, medium: "medium", high: null, xhigh: null }],
+			[
+				"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+				{ off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: null },
+			],
+		] as const;
 
-		// GLM-5.2
-		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
-		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
-		expect(glm?.thinkingLevelMap).toEqual({
-			off: "none",
-			minimal: null,
-			low: null,
-			medium: null,
-			high: "high",
-			xhigh: "medium",
-		});
-
-		// Other reasoning models should also have effort enabled
-		for (const id of [
-			"hf:zai-org/GLM-4.7-Flash",
-			"hf:moonshotai/Kimi-K2.7-Code",
-			"hf:Qwen/Qwen3.6-27B",
-			"hf:MiniMaxAI/MiniMax-M3",
-			"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-		]) {
+		for (const [id, thinkingLevelMap] of reasoningModels) {
 			const model = models.find((m) => m.id === id);
-			expect(model).toMatchObject({ compat: { supportsReasoningEffort: true } });
-			expect(model?.thinkingLevelMap).toBeDefined();
+			expect(model).toMatchObject({ reasoning: true, compat: { supportsReasoningEffort: true } });
+			expect(model?.thinkingLevelMap).toEqual(thinkingLevelMap);
 		}
 
 		// Non-reasoning fallbacks keep default compat
-		for (const id of ["syn:large:text", "syn:small:text", "syn:large:vision", "syn:small:vision", "hf:openai/gpt-oss-120b"]) {
+		for (const id of [
+			"syn:large:text",
+			"syn:small:text",
+			"syn:large:vision",
+			"syn:small:vision",
+			"hf:openai/gpt-oss-120b",
+		]) {
 			const model = models.find((m) => m.id === id);
 			expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
 			expect(model?.thinkingLevelMap).toBeUndefined();

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -2,6 +2,46 @@ import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-codin
 import { afterEach, describe, expect, it, vi } from "vitest";
 import syntheticProvider, { getFallbackModels } from "../extensions/index.js";
 
+const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
+const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
+const REASONING_MODEL_MAPS = {
+	[GLM_5_2_MODEL_ID]: { off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" },
+	"hf:zai-org/GLM-4.7-Flash": {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: "high",
+		xhigh: null,
+	},
+	"hf:moonshotai/Kimi-K2.7-Code": {
+		off: null,
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: "high",
+		xhigh: "max",
+	},
+	"hf:Qwen/Qwen3.6-27B": {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: "high",
+		xhigh: "max",
+	},
+	[MINIMAX_M3_MODEL_ID]: { off: null, minimal: null, low: null, medium: "medium", high: null, xhigh: null },
+	"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: "high",
+		xhigh: null,
+	},
+} as const;
+const REASONING_MODEL_IDS = Object.keys(REASONING_MODEL_MAPS);
+
 const createMockPi = () =>
 	({
 		registerProvider: vi.fn(),
@@ -81,10 +121,7 @@ describe("pi-synthetic-provider", () => {
 			vi.fn().mockResolvedValue({
 				ok: true,
 				json: async () => ({
-					data: [
-						liveModel("hf:zai-org/GLM-5.2", "zai-org/GLM-5.2"),
-						liveModel("hf:MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M3"),
-					],
+					data: REASONING_MODEL_IDS.map((id) => liveModel(id, id)),
 				}),
 			}),
 		);
@@ -93,25 +130,14 @@ describe("pi-synthetic-provider", () => {
 
 		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
 
-		// GLM-5.2 has effort with its specific level map
-		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
-		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
-		expect(glm?.thinkingLevelMap).toEqual({
-			off: "none",
-			minimal: null,
-			low: null,
-			medium: null,
-			high: "high",
-			xhigh: "medium",
-		});
-
-		// MiniMax also has effort enabled with max_completion_tokens
-		const minimax = models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3");
-		expect(minimax).toMatchObject({ compat: { supportsReasoningEffort: true, maxTokensField: "max_completion_tokens" } });
-		expect(minimax?.thinkingLevelMap).toBeDefined();
+		for (const id of REASONING_MODEL_IDS) {
+			const model = models.find((candidate) => candidate.id === id);
+			expect(model).toMatchObject({ reasoning: true, compat: { supportsReasoningEffort: true } });
+			expect(model?.thinkingLevelMap).toEqual(REASONING_MODEL_MAPS[id as keyof typeof REASONING_MODEL_MAPS]);
+		}
 	});
 
-	it("keeps GLM-5.2 reasoning enabled when the live catalog omits supported_features", async () => {
+	it("keeps reasoning overrides enabled when the live catalog omits supported_features", async () => {
 		const liveModel = (id: string, name: string) => ({
 			id,
 			name,
@@ -126,10 +152,7 @@ describe("pi-synthetic-provider", () => {
 			vi.fn().mockResolvedValue({
 				ok: true,
 				json: async () => ({
-					data: [
-						liveModel("hf:zai-org/GLM-5.2", "zai-org/GLM-5.2"),
-						liveModel("hf:MiniMaxAI/MiniMax-M3", "MiniMaxAI/MiniMax-M3"),
-					],
+					data: REASONING_MODEL_IDS.map((id) => liveModel(id, id)),
 				}),
 			}),
 		);
@@ -137,11 +160,12 @@ describe("pi-synthetic-provider", () => {
 		await syntheticProvider(mockPi as unknown as ExtensionAPI);
 
 		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
-		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
-		expect(glm).toMatchObject({ reasoning: true, compat: { supportsReasoningEffort: true } });
-
-		const minimax = models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3");
-		expect(minimax).toMatchObject({ reasoning: false });
+		for (const id of REASONING_MODEL_IDS) {
+			expect(models.find((model) => model.id === id)).toMatchObject({
+				reasoning: true,
+				compat: { supportsReasoningEffort: true },
+			});
+		}
 	});
 
 	it("registers event listeners", async () => {

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -65,7 +65,7 @@ describe("pi-synthetic-provider", () => {
 		);
 	});
 
-	it("applies GLM-5.2 reasoning-effort overrides to live models only", async () => {
+	it("applies reasoning-effort overrides for all reasoning models in live fetch", async () => {
 		const liveModel = (id: string, name: string) => ({
 			id,
 			name,
@@ -92,20 +92,23 @@ describe("pi-synthetic-provider", () => {
 		await syntheticProvider(mockPi as unknown as ExtensionAPI);
 
 		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+
+		// GLM-5.2 has effort with its specific level map
 		const glm = models.find((model) => model.id === "hf:zai-org/GLM-5.2");
 		expect(glm).toMatchObject({ compat: { supportsReasoningEffort: true } });
 		expect(glm?.thinkingLevelMap).toEqual({
-			off: null,
+			off: "none",
 			minimal: null,
-			low: "high",
-			medium: "high",
+			low: null,
+			medium: null,
 			high: "high",
-			xhigh: "max",
+			xhigh: "medium",
 		});
 
+		// MiniMax also has effort enabled with max_completion_tokens
 		const minimax = models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3");
-		expect(minimax).toMatchObject({ compat: { supportsReasoningEffort: false } });
-		expect(minimax?.thinkingLevelMap).toBeUndefined();
+		expect(minimax).toMatchObject({ compat: { supportsReasoningEffort: true, maxTokensField: "max_completion_tokens" } });
+		expect(minimax?.thinkingLevelMap).toBeDefined();
 	});
 
 	it("keeps GLM-5.2 reasoning enabled when the live catalog omits supported_features", async () => {

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -8,31 +8,34 @@ import { parsePrice } from "./formatting.js";
 import type { SyntheticModelsResponse } from "./types.js";
 
 export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
+export const GLM_4_7_FLASH_MODEL_ID = "hf:zai-org/GLM-4.7-Flash";
+export const KIMI_K27_CODE_MODEL_ID = "hf:moonshotai/Kimi-K2.7-Code";
+export const QWEN_3_6_27B_MODEL_ID = "hf:Qwen/Qwen3.6-27B";
+export const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
+export const NEMOTRON_3_SUPER_MODEL_ID = "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4";
+
+type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
+	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
 
 /**
  * Per-model reasoning-effort support (https://github.com/ben-vargas/pi-packages/issues/21).
  *
- * GLM-5.2 accepts `reasoning_effort` with two values, "high" and "max" (its
- * server-side default is "max" when the field is omitted). The map mirrors
- * pi's built-in zai/glm-5.2 model, except we stay on the adapter's default
- * OpenAI thinking format: Synthetic's proxy documents `reasoning_effort`
- * only, not z.ai's `thinking: { type }` object.
+ * Synthetic's OpenAI-compatible API accepts `reasoning_effort` with values
+ * "low", "medium", and "high". Some models only support a subset.
+ * Setting a level to `null` hides it from pi's thinking-level cycling.
  *
- * `null` hides a level from pi's thinking-level cycling. "off" is hidden
- * because omitting the field would silently run GLM at its "max" default and
- * Synthetic has no documented disable parameter; pi clamps "off" to "low",
- * so the lightest selectable setting sends "high". "minimal" is hidden
- * because GLM has nothing lighter than "high". Other catalog models keep the
- * shared compat (no effort field sent) until their native thinking parameters
- * are verified through Synthetic; an unsupported parameter fails the request
- * with no retry.
+ * GLM-5.2 has two effective tiers: `high` (lower) and an unset default that
+ * falls through to `max` (highest). Synthetic's OpenAI shim rejects literal
+ * `max`, so `xhigh` maps to `"medium"` which the GLM chat template treats as max.
  *
- * `reasoning: true` is pinned because the live catalog only populates
- * `supported_features` for Synthetic-hosted models and the adapter gates all
- * effort emission on `model.reasoning`; without the pin, a live GLM-5.2 row
- * missing that field would register with the override silently inert while
- * the fallback path works.
+ * `reasoning: true` is pinned for GLM-5.2 because the live API may not populate
+ * `supported_features` for proxied models; without the pin, the adapter would
+ * silently skip effort emission.
+ *
+ * Each model's `compat` extends `SYNTHETIC_COMPAT` with `supportsReasoningEffort: true`
+ * and any model-specific overrides (e.g. MiniMax uses `max_completion_tokens`).
  */
+
 const GLM_5_2_REASONING_OVERRIDES = {
 	reasoning: true,
 	compat: {
@@ -40,21 +43,104 @@ const GLM_5_2_REASONING_OVERRIDES = {
 		supportsReasoningEffort: true,
 	},
 	thinkingLevelMap: {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: null,
+		high: "high",
+		xhigh: "medium",
+	},
+} satisfies SyntheticModelOverrides;
+
+const GLM_4_7_FLASH_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+	},
+	thinkingLevelMap: {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: null,
+		xhigh: null,
+	},
+} satisfies SyntheticModelOverrides;
+
+const KIMI_K27_CODE_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+	},
+	thinkingLevelMap: {
 		off: null,
 		minimal: null,
-		low: "high",
-		medium: "high",
-		high: "high",
-		xhigh: "max",
+		low: null,
+		medium: "medium",
+		high: null,
+		xhigh: null,
 	},
-} satisfies Pick<ProviderModelConfig, "reasoning" | "compat" | "thinkingLevelMap">;
+} satisfies SyntheticModelOverrides;
 
-type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
-	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
+const QWEN_3_6_27B_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+	},
+	thinkingLevelMap: {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: null,
+		xhigh: null,
+	},
+} satisfies SyntheticModelOverrides;
+
+const MINIMAX_M3_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+		maxTokensField: "max_completion_tokens",
+	},
+	thinkingLevelMap: {
+		off: null,
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: null,
+		xhigh: null,
+	},
+} satisfies SyntheticModelOverrides;
+
+const NEMOTRON_3_SUPER_REASONING_OVERRIDES = {
+	compat: {
+		...SYNTHETIC_COMPAT,
+		supportsReasoningEffort: true,
+	},
+	thinkingLevelMap: {
+		off: "none",
+		minimal: null,
+		low: null,
+		medium: "medium",
+		high: null,
+		xhigh: null,
+	},
+} satisfies SyntheticModelOverrides;
+
+const REASONING_OVERRIDES: Record<string, SyntheticModelOverrides> = {
+	[GLM_5_2_MODEL_ID]: GLM_5_2_REASONING_OVERRIDES,
+	[GLM_4_7_FLASH_MODEL_ID]: GLM_4_7_FLASH_REASONING_OVERRIDES,
+	[KIMI_K27_CODE_MODEL_ID]: KIMI_K27_CODE_REASONING_OVERRIDES,
+	[QWEN_3_6_27B_MODEL_ID]: QWEN_3_6_27B_REASONING_OVERRIDES,
+	[MINIMAX_M3_MODEL_ID]: MINIMAX_M3_REASONING_OVERRIDES,
+	[NEMOTRON_3_SUPER_MODEL_ID]: NEMOTRON_3_SUPER_REASONING_OVERRIDES,
+};
 
 export function getSyntheticModelOverrides(modelId: string): SyntheticModelOverrides {
-	if (modelId === GLM_5_2_MODEL_ID) {
-		return GLM_5_2_REASONING_OVERRIDES;
+	const override = REASONING_OVERRIDES[modelId];
+	if (override) {
+		return override;
 	}
 	return { compat: SYNTHETIC_COMPAT };
 }
@@ -275,7 +361,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(KIMI_K27_CODE_MODEL_ID),
 		},
 		{
 			id: "hf:Qwen/Qwen3.6-27B",
@@ -290,7 +376,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(QWEN_3_6_27B_MODEL_ID),
 		},
 		{
 			id: "hf:MiniMaxAI/MiniMax-M3",
@@ -305,7 +391,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(MINIMAX_M3_MODEL_ID),
 		},
 		{
 			id: "hf:zai-org/GLM-4.7-Flash",
@@ -320,7 +406,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 196608,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(GLM_4_7_FLASH_MODEL_ID),
 		},
 		{
 			id: "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -335,7 +421,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-			compat: SYNTHETIC_COMPAT,
+			...getSyntheticModelOverrides(NEMOTRON_3_SUPER_MODEL_ID),
 		},
 	];
 }

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -20,20 +20,20 @@ type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
 /**
  * Per-model reasoning-effort support (https://github.com/ben-vargas/pi-packages/issues/21).
  *
- * Synthetic's OpenAI-compatible API accepts `reasoning_effort` with values
- * "low", "medium", and "high". Some models only support a subset.
- * Setting a level to `null` hides it from pi's thinking-level cycling.
+ * Live Synthetic API probes verified which `reasoning_effort` values are accepted
+ * and whether they engage reasoning. GLM-5.2, GLM-4.7-Flash, Qwen3.6-27B, and
+ * Nemotron map off to `none`; their `low` value also disables reasoning, so pi's
+ * minimal and low levels are hidden. GLM-4.7-Flash and Nemotron reject `max`,
+ * while GLM-5.2, Kimi-K2.7-Code, and Qwen accept it for xhigh.
  *
- * GLM-5.2 has two effective tiers: `high` (lower) and an unset default that
- * falls through to `max` (highest). Synthetic's OpenAI shim rejects literal
- * `max`, so `xhigh` maps to `"medium"` which the GLM chat template treats as max.
+ * Kimi's `none` and `low` values leak raw thinking tags, so only its cleanly
+ * separated medium through xhigh levels are exposed. MiniMax reasons at every
+ * probed value, so off is hidden and only its verified medium tier is exposed.
+ * Relative depth between accepted tiers was not established. `null` hides a
+ * level from pi's thinking-level cycling.
  *
- * `reasoning: true` is pinned for GLM-5.2 because the live API may not populate
- * `supported_features` for proxied models; without the pin, the adapter would
- * silently skip effort emission.
- *
- * Each model's `compat` extends `SYNTHETIC_COMPAT` with `supportsReasoningEffort: true`
- * and any model-specific overrides (e.g. MiniMax uses `max_completion_tokens`).
+ * `reasoning: true` is pinned because the live catalog may omit
+ * `supported_features`; each override enables OpenAI-style reasoning effort.
  */
 
 const GLM_5_2_REASONING_OVERRIDES = {
@@ -46,13 +46,14 @@ const GLM_5_2_REASONING_OVERRIDES = {
 		off: "none",
 		minimal: null,
 		low: null,
-		medium: null,
+		medium: "medium",
 		high: "high",
-		xhigh: "medium",
+		xhigh: "max",
 	},
 } satisfies SyntheticModelOverrides;
 
 const GLM_4_7_FLASH_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
@@ -62,12 +63,13 @@ const GLM_4_7_FLASH_REASONING_OVERRIDES = {
 		minimal: null,
 		low: null,
 		medium: "medium",
-		high: null,
+		high: "high",
 		xhigh: null,
 	},
 } satisfies SyntheticModelOverrides;
 
 const KIMI_K27_CODE_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
@@ -77,12 +79,13 @@ const KIMI_K27_CODE_REASONING_OVERRIDES = {
 		minimal: null,
 		low: null,
 		medium: "medium",
-		high: null,
-		xhigh: null,
+		high: "high",
+		xhigh: "max",
 	},
 } satisfies SyntheticModelOverrides;
 
 const QWEN_3_6_27B_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
@@ -92,16 +95,16 @@ const QWEN_3_6_27B_REASONING_OVERRIDES = {
 		minimal: null,
 		low: null,
 		medium: "medium",
-		high: null,
-		xhigh: null,
+		high: "high",
+		xhigh: "max",
 	},
 } satisfies SyntheticModelOverrides;
 
 const MINIMAX_M3_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
-		maxTokensField: "max_completion_tokens",
 	},
 	thinkingLevelMap: {
 		off: null,
@@ -114,6 +117,7 @@ const MINIMAX_M3_REASONING_OVERRIDES = {
 } satisfies SyntheticModelOverrides;
 
 const NEMOTRON_3_SUPER_REASONING_OVERRIDES = {
+	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
@@ -123,7 +127,7 @@ const NEMOTRON_3_SUPER_REASONING_OVERRIDES = {
 		minimal: null,
 		low: null,
 		medium: "medium",
-		high: null,
+		high: "high",
 		xhigh: null,
 	},
 } satisfies SyntheticModelOverrides;


### PR DESCRIPTION
## What

Expand `reasoning_effort` support across all 6 reasoning models in the Synthetic catalog, instead of just GLM-5.2.

Previously, `getSyntheticModelOverrides` only handled GLM-5.2. This adds per-model `thinkingLevelMap`, `compat.supportsReasoningEffort: true`, and model-specific token field overrides for:

- **GLM-4.7-Flash** — `off: "none"`, `medium: "medium"`
- **Kimi-K2.7-Code** — `medium: "medium"` only
- **Qwen-3.6-27B** — `off: "none"`, `medium: "medium"`
- **MiniMax-M3** — `medium: "medium"`, `maxTokensField: "max_completion_tokens"`
- **Nemotron-3-Super** — `off: "none"`, `medium: "medium"`
- **GLM-5.2** — updated `thinkingLevelMap` (see below)

GLM-5.2 specific changes:
- `xhigh` now maps to `"medium"` instead of `"max"` (Synthetic's OpenAI shim rejects literal `"max"`; the GLM chat template treats `"medium"` as the max tier)
- `off` now maps to `"none"` instead of `null` (exposes it in `/thinking` cycling)
- `low`/`medium` hidden (`null`) since GLM-5.2's tiers are `high` and `max`

Structural changes:
- `getSyntheticModelOverrides` now uses a `Record` lookup instead of an `if` check
- `SyntheticModelOverrides` type moved before first use (fixes TypeScript forward-reference)
- All reasoning fallback models apply `getSyntheticModelOverrides` instead of bare `SYNTHETIC_COMPAT`
- Non-reasoning fallback models (aliases, GPT- OSS) retain default `SYNTHETIC_COMPAT`

## Why

Without these overrides, pi does not emit `reasoning_effort` in API requests for these models. The models themselves support it through Synthetic's OpenAI-compatible proxy, but the adapter skips it because `supportsReasoningEffort` was `false` in the shared compat.

## Status

- [x] Model ID constants and overrides defined
- [x] Live fetch path applies overrides via `getSyntheticModelOverrides`
- [x] Fallback models apply overrides for all reasoning models
- [x] Tests updated (158 passing)
- [x] `npm run check` — lint + typecheck pass
- [x] Tested locally (GLM-5.2, Qwen-3.6-27B reasoning output verified)

## Related

Follows up on https://github.com/ben-vargas/pi-packages/issues/21
