### PR TITLE
feat(pi-openai-fast): support GPT-5.6 fast mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4779,7 +4779,7 @@
     },
     "packages/pi-openai-fast": {
       "name": "@benvargas/pi-openai-fast",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.74.0"

--- a/packages/pi-openai-fast/CHANGELOG.md
+++ b/packages/pi-openai-fast/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.5] - 2026-07-14
+
+### Added
+- Added fast mode support for GPT-5.6 Sol, Terra, and Luna on both the `openai` and `openai-codex` providers.
+- Added regression coverage for GPT-5.6 model matching and default configuration.
+
+### Changed
+- Migrated the previous GPT-5.4-only and GPT-5.4/GPT-5.5 default model lists to include supported GPT-5.6 variants while preserving custom `supportedModels` lists.

--- a/packages/pi-openai-fast/README.md
+++ b/packages/pi-openai-fast/README.md
@@ -52,8 +52,14 @@ Default config:
   "supportedModels": [
     "openai/gpt-5.4",
     "openai/gpt-5.5",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
     "openai-codex/gpt-5.4",
-    "openai-codex/gpt-5.5"
+    "openai-codex/gpt-5.5",
+    "openai-codex/gpt-5.6-sol",
+    "openai-codex/gpt-5.6-terra",
+    "openai-codex/gpt-5.6-luna"
   ]
 }
 ```

--- a/packages/pi-openai-fast/__tests__/helpers.test.ts
+++ b/packages/pi-openai-fast/__tests__/helpers.test.ts
@@ -28,15 +28,13 @@ function createTempConfigPaths(): { cwd: string; homeDir: string; cleanup: () =>
 
 describe("pi-openai-fast helpers", () => {
 	it("parses supported model keys and recognizes supported fast models", () => {
-		const supportedModels =
-			_test.parseSupportedModels([
-				"openai/gpt-5.4",
-				"openai/gpt-5.5",
-				"openai-codex/gpt-5.4",
-				"openai-codex/gpt-5.5",
-			]) ?? [];
+		const supportedModels = _test.parseSupportedModels(_test.DEFAULT_SUPPORTED_MODEL_KEYS) ?? [];
 		expect(_test.parseSupportedModelKey("openai/gpt-5.4")).toEqual({ provider: "openai", id: "gpt-5.4" });
 		expect(_test.parseSupportedModelKey("openai/gpt-5.5")).toEqual({ provider: "openai", id: "gpt-5.5" });
+		expect(_test.parseSupportedModelKey("openai/gpt-5.6-sol")).toEqual({
+			provider: "openai",
+			id: "gpt-5.6-sol",
+		});
 		expect(_test.parseSupportedModelKey("invalid-model")).toBeUndefined();
 		expect(
 			_test.isFastSupportedModel({ provider: "openai", id: "gpt-5.4" } as ExtensionContext["model"], supportedModels),
@@ -53,6 +51,18 @@ describe("pi-openai-fast helpers", () => {
 		expect(
 			_test.isFastSupportedModel(
 				{ provider: "openai-codex", id: "gpt-5.5" } as ExtensionContext["model"],
+				supportedModels,
+			),
+		).toBe(true);
+		expect(
+			_test.isFastSupportedModel(
+				{ provider: "openai", id: "gpt-5.6-luna" } as ExtensionContext["model"],
+				supportedModels,
+			),
+		).toBe(true);
+		expect(
+			_test.isFastSupportedModel(
+				{ provider: "openai-codex", id: "gpt-5.6-terra" } as ExtensionContext["model"],
 				supportedModels,
 			),
 		).toBe(true);
@@ -75,8 +85,14 @@ describe("pi-openai-fast helpers", () => {
 			expect(defaultConfig.supportedModels).toEqual([
 				{ provider: "openai", id: "gpt-5.4" },
 				{ provider: "openai", id: "gpt-5.5" },
+				{ provider: "openai", id: "gpt-5.6-sol" },
+				{ provider: "openai", id: "gpt-5.6-terra" },
+				{ provider: "openai", id: "gpt-5.6-luna" },
 				{ provider: "openai-codex", id: "gpt-5.4" },
 				{ provider: "openai-codex", id: "gpt-5.5" },
+				{ provider: "openai-codex", id: "gpt-5.6-sol" },
+				{ provider: "openai-codex", id: "gpt-5.6-terra" },
+				{ provider: "openai-codex", id: "gpt-5.6-luna" },
 			]);
 
 			const { projectConfigPath, globalConfigPath } = _test.getConfigPaths(cwd, homeDir);
@@ -104,12 +120,9 @@ describe("pi-openai-fast helpers", () => {
 	});
 
 	it("migrates legacy default supported models without changing custom supported models", () => {
-		expect(_test.migrateSupportedModelKeys(["openai/gpt-5.4", "openai-codex/gpt-5.4"])).toEqual([
-			"openai/gpt-5.4",
-			"openai/gpt-5.5",
-			"openai-codex/gpt-5.4",
-			"openai-codex/gpt-5.5",
-		]);
+		for (const legacyKeys of _test.LEGACY_DEFAULT_SUPPORTED_MODEL_KEY_SETS) {
+			expect(_test.migrateSupportedModelKeys([...legacyKeys])).toEqual([..._test.DEFAULT_SUPPORTED_MODEL_KEYS]);
+		}
 		expect(_test.migrateSupportedModelKeys(["openai/gpt-5.4"])).toEqual(["openai/gpt-5.4"]);
 		expect(_test.migrateSupportedModelKeys(undefined)).toBeUndefined();
 	});

--- a/packages/pi-openai-fast/__tests__/index.test.ts
+++ b/packages/pi-openai-fast/__tests__/index.test.ts
@@ -179,7 +179,7 @@ describe("pi-openai-fast", () => {
 			expect(JSON.parse(readFileSync(globalConfigPath, "utf-8"))).toEqual({
 				persistState: true,
 				active: true,
-				supportedModels: ["openai/gpt-5.4", "openai/gpt-5.5", "openai-codex/gpt-5.4", "openai-codex/gpt-5.5"],
+				supportedModels: [..._test.DEFAULT_SUPPORTED_MODEL_KEYS],
 			});
 		} finally {
 			cleanup();
@@ -208,7 +208,7 @@ describe("pi-openai-fast", () => {
 			await command.handler("on", ctx);
 
 			expect(ui.notify).toHaveBeenCalledWith(
-				"Fast mode is on, but anthropic/claude-sonnet-4 does not support it. Supported models: openai/gpt-5.4, openai/gpt-5.5, openai-codex/gpt-5.4, openai-codex/gpt-5.5.",
+				`Fast mode is on, but anthropic/claude-sonnet-4 does not support it. Supported models: ${_test.DEFAULT_SUPPORTED_MODEL_KEYS.join(", ")}.`,
 				"info",
 			);
 

--- a/packages/pi-openai-fast/extensions/index.ts
+++ b/packages/pi-openai-fast/extensions/index.ts
@@ -23,10 +23,19 @@ const FAST_SERVICE_TIER = "priority";
 const DEFAULT_SUPPORTED_MODEL_KEYS = [
 	"openai/gpt-5.4",
 	"openai/gpt-5.5",
+	"openai/gpt-5.6-sol",
+	"openai/gpt-5.6-terra",
+	"openai/gpt-5.6-luna",
 	"openai-codex/gpt-5.4",
 	"openai-codex/gpt-5.5",
+	"openai-codex/gpt-5.6-sol",
+	"openai-codex/gpt-5.6-terra",
+	"openai-codex/gpt-5.6-luna",
 ] as const;
-const LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS = ["openai/gpt-5.4", "openai-codex/gpt-5.4"] as const;
+const LEGACY_DEFAULT_SUPPORTED_MODEL_KEY_SETS = [
+	["openai/gpt-5.4", "openai-codex/gpt-5.4"],
+	["openai/gpt-5.4", "openai/gpt-5.5", "openai-codex/gpt-5.4", "openai-codex/gpt-5.5"],
+] as const;
 
 interface FastModeState {
 	active: boolean;
@@ -146,7 +155,7 @@ function sameModelKeys(left: readonly string[] | undefined, right: readonly stri
 }
 
 function migrateSupportedModelKeys(value: string[] | undefined): string[] | undefined {
-	if (sameModelKeys(value, LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS)) {
+	if (LEGACY_DEFAULT_SUPPORTED_MODEL_KEY_SETS.some((legacyKeys) => sameModelKeys(value, legacyKeys))) {
 		return [...DEFAULT_SUPPORTED_MODEL_KEYS];
 	}
 	return value;
@@ -400,7 +409,7 @@ export const _test = {
 	FAST_COMMAND_ARGS,
 	FAST_SERVICE_TIER,
 	DEFAULT_SUPPORTED_MODEL_KEYS,
-	LEGACY_DEFAULT_SUPPORTED_MODEL_KEYS,
+	LEGACY_DEFAULT_SUPPORTED_MODEL_KEY_SETS,
 	DEFAULT_CONFIG_FILE,
 	getConfigPaths,
 	parseSupportedModelKey,

--- a/packages/pi-openai-fast/package.json
+++ b/packages/pi-openai-fast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-openai-fast",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenAI fast mode toggle for pi - Enables priority service tier on supported GPT-5 models",
   "keywords": [
     "pi",
@@ -11,6 +11,7 @@
     "codex",
     "gpt-5.4",
     "gpt-5.5",
+    "gpt-5.6",
     "fast",
     "priority",
     "service-tier"


### PR DESCRIPTION
## Summary
- add fast/priority service-tier support for GPT-5.6 Sol, Terra, and Luna on the `openai` and `openai-codex` providers
- migrate both historical default supported-model lists while preserving custom lists
- bump `@benvargas/pi-openai-fast` to 1.0.5 and add a changelog entry
- update documentation and regression coverage

Fast-mode availability was verified against the current OpenAI Codex model catalog and the locally fetched `~/.codex/models_cache.json`; all three GPT-5.6 variants advertise the `priority` service tier as Fast.

## Tests
- `npm run check`
- `npm run test` (158 tests passed)