### PR TITLE
feat(pi-synthetic-provider): add Kimi K3, retire K2.7-Code, fix fallback cache pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pi packages can include extensions, skills, prompt templates, and themes. See th
 
 | Package | Type | Description |
 |---------|------|-------------|
-| [@benvargas/pi-synthetic-provider](./packages/pi-synthetic-provider/) | Extension | [Synthetic](https://synthetic.new) model provider (Kimi, GLM, MiniMax, DeepSeek, Qwen) |
+| [@benvargas/pi-synthetic-provider](./packages/pi-synthetic-provider/) | Extension | [Synthetic](https://synthetic.new) model provider (Kimi, GLM, MiniMax, Qwen, Nemotron, gpt-oss) |
 | [@benvargas/pi-antigravity-image-gen](./packages/pi-antigravity-image-gen/) | Extension | Antigravity image generation (Gemini 3 Pro, inline rendering) |
 | [@benvargas/pi-exa-mcp](./packages/pi-exa-mcp/) | Extension | Exa MCP tools — web search + code context |
 | [@benvargas/pi-firecrawl](./packages/pi-firecrawl/) | Extension | Firecrawl tools — scrape, map, search |

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `hf:moonshotai/Kimi-K3` to fallback models with thinking-level support, verified against live `reasoning_effort` probes: `off` → `none`, `medium` → `medium`, `high` → `high`, `xhigh` → `max`. Unlike Kimi-K2.7-Code, K3 returns clean content at `none` and `low` rather than leaking raw thinking tags, so `off` is selectable. `low`/`minimal` stay hidden because the provider-side `low` value disables reasoning outright, matching the treatment of the other reasoning models.
+
+### Removed
+- Removed `hf:moonshotai/Kimi-K2.7-Code` from fallback models and from the reasoning-override table. Synthetic retired it from the catalog alongside the K3 launch, earlier than the launch announcement suggested.
+
+### Deprecated
+- `KIMI_K27_CODE_MODEL_ID` is deprecated but still exported with its original value. The model it names is gone, so it no longer appears in the fallback list or the reasoning-override table, but `extensions/` ships in the published package and removing the named export outright would break deep imports. Use `KIMI_K3_MODEL_ID`, or the `syn:large:vision` permalink that Synthetic re-pointed to K3.
+
+### Changed
+- Re-pointed the `syn:large:vision` fallback entry from Kimi K2.7-Code to Kimi K3: 512K context (was 256K) and $3.00/$15.00 pricing (was $0.95/$4.00). Sessions pinned to the permalink pick this up automatically.
+- Refreshed all fallback pricing and context windows against the live `always_on` catalog as of 2026-07-28. `syn:large:text` and GLM 5.2 drop to $1.00/$3.00 (were $1.40/$4.40).
+
+### Fixed
+- Fallback `cacheRead` prices now use the catalog's `input_cache_reads` rate instead of mirroring the input price. Every fallback entry was affected. On `hf:zai-org/GLM-5.2`, an entry that already existed in 1.2.1, cached reads were billed at $1.40 rather than $0.16 — a ~8.75x cost-tracking overstatement whenever the fallback path was in use. Live catalog discovery already read the correct field, so only fallback sessions were affected.
+
 ## [1.2.1] - 2026-07-16
 
 ### Fixed

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -7,7 +7,7 @@
 - **Dynamic model discovery** -- models fetched live from the Synthetic API at each session start
 - **OpenAI Completions API** -- reuses pi's built-in streaming, no custom implementation
 - **Tool calling** -- full support via OpenAI-compatible tool use
-- **Vision support** -- image input for models that support it (e.g., Kimi-K2.7-Code)
+- **Vision support** -- image input for models that support it (e.g., Kimi-K3)
 - **Reasoning support** -- extended thinking for reasoning-capable models
 - **Cost tracking** -- accurate per-token pricing parsed from the API
 - **Graceful degradation** -- fallback model list if the API is unreachable
@@ -49,7 +49,7 @@ Add to `~/.pi/agent/auth.json`:
 ### Option 3: Runtime CLI Flag
 
 ```bash
-pi --model synthetic/hf:moonshotai/Kimi-K2.7-Code --api-key syn_your_key_here
+pi --model synthetic/hf:moonshotai/Kimi-K3 --api-key syn_your_key_here
 ```
 
 ## Usage
@@ -59,10 +59,10 @@ pi --model synthetic/hf:moonshotai/Kimi-K2.7-Code --api-key syn_your_key_here
 pi /model
 
 # Direct model selection
-pi --model synthetic/hf:moonshotai/Kimi-K2.7-Code
+pi --model synthetic/hf:moonshotai/Kimi-K3
 
 # Or use provider + model flags separately
-pi --provider synthetic --model hf:moonshotai/Kimi-K2.7-Code
+pi --provider synthetic --model hf:moonshotai/Kimi-K3
 ```
 
 ### Extension Command
@@ -74,21 +74,25 @@ pi --provider synthetic --model hf:moonshotai/Kimi-K2.7-Code
 
 Models are fetched at startup from the [Synthetic models endpoint](https://dev.synthetic.new/docs/api/models). If the startup fetch fails, times out after three seconds, or returns no supported models, the provider falls back to the following hardcoded defaults:
 
-| Model | ID | Reasoning | Vision | Context | Max Output |
-|-------|-----|-----------|--------|---------|------------|
-| **Synthetic Large Text** | `syn:large:text` | Yes | No | 524K | 65K |
-| **Synthetic Small Text** | `syn:small:text` | Yes | No | 196K | 65K |
-| **Synthetic Large Vision** | `syn:large:vision` | Yes | Yes | 262K | 65K |
-| **Synthetic Small Vision** | `syn:small:vision` | Yes | Yes | 262K | 65K |
-| **GLM 5.2** | `hf:zai-org/GLM-5.2` | Yes | No | 524K | 65K |
-| **GPT OSS 120B** | `hf:openai/gpt-oss-120b` | Yes | No | 131K | 65K |
-| **Kimi K2.7 Code** | `hf:moonshotai/Kimi-K2.7-Code` | Yes | Yes | 262K | 65K |
-| **Qwen 3.6 27B** | `hf:Qwen/Qwen3.6-27B` | Yes | Yes | 262K | 65K |
-| **MiniMax M3** | `hf:MiniMaxAI/MiniMax-M3` | Yes | Yes | 262K | 65K |
-| **GLM 4.7 Flash** | `hf:zai-org/GLM-4.7-Flash` | Yes | No | 196K | 65K |
-| **Nemotron 3 Super 120B** | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | Yes | No | 262K | 65K |
+Prices are $ per million tokens, current as of 2026-07-28.
 
-Run `/synthetic-models` inside pi for the live catalog.
+| Model | ID | Reasoning | Vision | Context | Max Output | In / Out / Cache |
+|-------|-----|-----------|--------|---------|------------|------------------|
+| **Synthetic Large Text** | `syn:large:text` | Yes | No | 524K | 65K | 1.00 / 3.00 / 0.16 |
+| **Synthetic Small Text** | `syn:small:text` | Yes | No | 196K | 65K | 0.10 / 0.50 / 0.02 |
+| **Synthetic Large Vision** | `syn:large:vision` | Yes | Yes | 524K | 65K | 3.00 / 15.00 / 0.45 |
+| **Synthetic Small Vision** | `syn:small:vision` | Yes | Yes | 262K | 65K | 0.45 / 3.60 / 0.09 |
+| **GLM 5.2** | `hf:zai-org/GLM-5.2` | Yes | No | 524K | 65K | 1.00 / 3.00 / 0.16 |
+| **GPT OSS 120B** | `hf:openai/gpt-oss-120b` | Yes | No | 131K | 65K | 0.10 / 0.10 / 0.02 |
+| **Kimi K3** | `hf:moonshotai/Kimi-K3` | Yes | Yes | 524K | 65K | 3.00 / 15.00 / 0.45 |
+| **Qwen 3.6 27B** | `hf:Qwen/Qwen3.6-27B` | Yes | Yes | 262K | 65K | 0.45 / 3.60 / 0.09 |
+| **MiniMax M3** | `hf:MiniMaxAI/MiniMax-M3` | Yes | Yes | 262K | 65K | 0.60 / 1.20 / 0.12 |
+| **GLM 4.7 Flash** | `hf:zai-org/GLM-4.7-Flash` | Yes | No | 196K | 65K | 0.10 / 0.50 / 0.02 |
+| **Nemotron 3 Super 120B** | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | Yes | No | 262K | 65K | 0.30 / 1.00 / 0.06 |
+
+The `syn:*` ids are permalinks that Synthetic re-points as models rotate, so configs using them survive model retirements — `syn:large:vision` moved from Kimi K2.7-Code to Kimi K3 in this release. The `hf:*` ids pin a specific model and break when it is retired.
+
+Kimi K3 is at beta launch pricing; Synthetic expects to lower it as engine optimization improves. Run `/synthetic-models` inside pi for the live catalog.
 
 ## API Key Priority
 

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -28,7 +28,7 @@ describe("pi-synthetic-provider helpers", () => {
 			"syn:small:vision",
 			"hf:openai/gpt-oss-120b",
 			"hf:zai-org/GLM-5.2",
-			"hf:moonshotai/Kimi-K2.7-Code",
+			"hf:moonshotai/Kimi-K3",
 			"hf:Qwen/Qwen3.6-27B",
 			"hf:MiniMaxAI/MiniMax-M3",
 			"hf:zai-org/GLM-4.7-Flash",
@@ -38,6 +38,7 @@ describe("pi-synthetic-provider helpers", () => {
 		for (const staleId of [
 			"hf:zai-org/GLM-5.1",
 			"hf:moonshotai/Kimi-K2.6",
+			"hf:moonshotai/Kimi-K2.7-Code",
 			"hf:zai-org/GLM-4.7",
 			"hf:Qwen/Qwen3.5-397B-A17B",
 		]) {
@@ -51,6 +52,48 @@ describe("pi-synthetic-provider helpers", () => {
 		expect(models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3")).toMatchObject({
 			contextWindow: 262144,
 		});
+		expect(models.find((model) => model.id === "hf:moonshotai/Kimi-K3")).toMatchObject({
+			contextWindow: 524288,
+			input: ["text", "image"],
+			cost: { input: 3, output: 15, cacheRead: 0.45 },
+		});
+		// syn:large:vision was re-pointed from Kimi K2.7-Code to Kimi K3.
+		expect(models.find((model) => model.id === "syn:large:vision")).toMatchObject({
+			contextWindow: 524288,
+			cost: { input: 3, output: 15, cacheRead: 0.45 },
+		});
+	});
+
+	it("matches the live catalog price for every fallback model", () => {
+		// Exact expected values, not merely cacheRead < input: the bug being guarded
+		// against set cacheRead equal to input, and a too-low wrong value would still
+		// satisfy an inequality. Sourced from input_cache_reads in the 2026-07-28
+		// authenticated catalog pull.
+		const expected: Record<string, { input: number; output: number; cacheRead: number }> = {
+			"syn:large:text": { input: 1, output: 3, cacheRead: 0.16 },
+			"syn:small:text": { input: 0.1, output: 0.5, cacheRead: 0.02 },
+			"syn:large:vision": { input: 3, output: 15, cacheRead: 0.45 },
+			"syn:small:vision": { input: 0.45, output: 3.6, cacheRead: 0.09 },
+			"hf:openai/gpt-oss-120b": { input: 0.1, output: 0.1, cacheRead: 0.02 },
+			"hf:zai-org/GLM-5.2": { input: 1, output: 3, cacheRead: 0.16 },
+			"hf:moonshotai/Kimi-K3": { input: 3, output: 15, cacheRead: 0.45 },
+			"hf:Qwen/Qwen3.6-27B": { input: 0.45, output: 3.6, cacheRead: 0.09 },
+			"hf:MiniMaxAI/MiniMax-M3": { input: 0.6, output: 1.2, cacheRead: 0.12 },
+			"hf:zai-org/GLM-4.7-Flash": { input: 0.1, output: 0.5, cacheRead: 0.02 },
+			"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": { input: 0.3, output: 1, cacheRead: 0.06 },
+		};
+
+		const models = getFallbackModels();
+		expect(models.map((model) => model.id).sort()).toEqual(Object.keys(expected).sort());
+
+		for (const model of models) {
+			expect({ id: model.id, ...model.cost, cacheWrite: undefined }).toMatchObject({
+				id: model.id,
+				...expected[model.id],
+			});
+			expect(model.cost.cacheWrite).toBe(0);
+			expect(model.cost.cacheRead).toBeLessThan(model.cost.input);
+		}
 	});
 
 	it("enables reasoning effort for all reasoning models in fallback models", () => {
@@ -62,8 +105,8 @@ describe("pi-synthetic-provider helpers", () => {
 				{ off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: null },
 			],
 			[
-				"hf:moonshotai/Kimi-K2.7-Code",
-				{ off: null, minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" },
+				"hf:moonshotai/Kimi-K3",
+				{ off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" },
 			],
 			["hf:Qwen/Qwen3.6-27B", { off: "none", minimal: null, low: null, medium: "medium", high: "high", xhigh: "max" }],
 			["hf:MiniMaxAI/MiniMax-M3", { off: null, minimal: null, low: null, medium: "medium", high: null, xhigh: null }],

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -15,8 +15,8 @@ const REASONING_MODEL_MAPS = {
 		high: "high",
 		xhigh: null,
 	},
-	"hf:moonshotai/Kimi-K2.7-Code": {
-		off: null,
+	"hf:moonshotai/Kimi-K3": {
+		off: "none",
 		minimal: null,
 		low: null,
 		medium: "medium",

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -9,10 +9,20 @@ import type { SyntheticModelsResponse } from "./types.js";
 
 export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
 export const GLM_4_7_FLASH_MODEL_ID = "hf:zai-org/GLM-4.7-Flash";
-export const KIMI_K27_CODE_MODEL_ID = "hf:moonshotai/Kimi-K2.7-Code";
+export const KIMI_K3_MODEL_ID = "hf:moonshotai/Kimi-K3";
 export const QWEN_3_6_27B_MODEL_ID = "hf:Qwen/Qwen3.6-27B";
 export const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
 export const NEMOTRON_3_SUPER_MODEL_ID = "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4";
+
+/**
+ * @deprecated Synthetic retired this model alongside the Kimi K3 launch, so it no
+ * longer appears in the catalog, in the fallback list, or in the reasoning-effort
+ * table. The constant is retained only so deep imports of `extensions/models.js`
+ * keep resolving — `extensions/` ships in the published package. Use
+ * {@link KIMI_K3_MODEL_ID}, or the `syn:large:vision` permalink, which Synthetic
+ * re-pointed from this model to K3.
+ */
+export const KIMI_K27_CODE_MODEL_ID = "hf:moonshotai/Kimi-K2.7-Code";
 
 type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
 	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
@@ -21,14 +31,15 @@ type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
  * Per-model reasoning-effort support (https://github.com/ben-vargas/pi-packages/issues/21).
  *
  * Live Synthetic API probes verified which `reasoning_effort` values are accepted
- * and whether they engage reasoning. GLM-5.2, GLM-4.7-Flash, Qwen3.6-27B, and
- * Nemotron map off to `none`; their `low` value also disables reasoning, so pi's
- * minimal and low levels are hidden. GLM-4.7-Flash and Nemotron reject `max`,
- * while GLM-5.2, Kimi-K2.7-Code, and Qwen accept it for xhigh.
+ * and whether they engage reasoning. GLM-5.2, GLM-4.7-Flash, Qwen3.6-27B,
+ * Nemotron, and Kimi-K3 map off to `none`; their `low` value also disables
+ * reasoning, so pi's minimal and low levels are hidden. GLM-4.7-Flash and
+ * Nemotron reject `max`, while GLM-5.2, Kimi-K3, and Qwen accept it for xhigh.
  *
- * Kimi's `none` and `low` values leak raw thinking tags, so only its cleanly
- * separated medium through xhigh levels are exposed. MiniMax reasons at every
- * probed value, so off is hidden and only its verified medium tier is exposed.
+ * Kimi-K3 supersedes Kimi-K2.7-Code here. K2.7-Code leaked raw thinking tags at
+ * `none`/`low`, which forced its `off` level to stay hidden; K3 returns clean
+ * content at both, so `off` is selectable. MiniMax reasons at every probed
+ * value, so off is hidden and only its verified medium tier is exposed.
  * Relative depth between accepted tiers was not established. `null` hides a
  * level from pi's thinking-level cycling.
  *
@@ -68,14 +79,14 @@ const GLM_4_7_FLASH_REASONING_OVERRIDES = {
 	},
 } satisfies SyntheticModelOverrides;
 
-const KIMI_K27_CODE_REASONING_OVERRIDES = {
+const KIMI_K3_REASONING_OVERRIDES = {
 	reasoning: true,
 	compat: {
 		...SYNTHETIC_COMPAT,
 		supportsReasoningEffort: true,
 	},
 	thinkingLevelMap: {
-		off: null,
+		off: "none",
 		minimal: null,
 		low: null,
 		medium: "medium",
@@ -135,7 +146,7 @@ const NEMOTRON_3_SUPER_REASONING_OVERRIDES = {
 const REASONING_OVERRIDES: Record<string, SyntheticModelOverrides> = {
 	[GLM_5_2_MODEL_ID]: GLM_5_2_REASONING_OVERRIDES,
 	[GLM_4_7_FLASH_MODEL_ID]: GLM_4_7_FLASH_REASONING_OVERRIDES,
-	[KIMI_K27_CODE_MODEL_ID]: KIMI_K27_CODE_REASONING_OVERRIDES,
+	[KIMI_K3_MODEL_ID]: KIMI_K3_REASONING_OVERRIDES,
 	[QWEN_3_6_27B_MODEL_ID]: QWEN_3_6_27B_REASONING_OVERRIDES,
 	[MINIMAX_M3_MODEL_ID]: MINIMAX_M3_REASONING_OVERRIDES,
 	[NEMOTRON_3_SUPER_MODEL_ID]: NEMOTRON_3_SUPER_REASONING_OVERRIDES,
@@ -256,9 +267,14 @@ export async function fetchSyntheticModels(
 /**
  * Fallback models if API fetch fails.
  * Data sourced from: authenticated GET https://api.synthetic.new/openai/v1/models
- * Last updated: 2026-07-04
+ * Last updated: 2026-07-28
  *
- * Pricing format: $/million tokens
+ * Mirrors the live `always_on` catalog. The `syn:*` permalinks are stable
+ * aliases Synthetic re-points as models rotate; `syn:large:vision` now resolves
+ * to Kimi K3 (was Kimi K2.7-Code, since retired) and `syn:large:text` to GLM 5.2.
+ *
+ * Pricing format: $/million tokens. `cacheRead` tracks the catalog's
+ * `input_cache_reads` rate, which is well below the input rate on every model.
  */
 export function getFallbackModels(): ProviderModelConfig[] {
 	return [
@@ -268,9 +284,9 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			reasoning: true,
 			input: ["text"],
 			cost: {
-				input: 1.4,
-				output: 4.4,
-				cacheRead: 1.4,
+				input: 1,
+				output: 3,
+				cacheRead: 0.16,
 				cacheWrite: 0,
 			},
 			contextWindow: 524288,
@@ -285,7 +301,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			cost: {
 				input: 0.1,
 				output: 0.5,
-				cacheRead: 0.1,
+				cacheRead: 0.02,
 				cacheWrite: 0,
 			},
 			contextWindow: 196608,
@@ -298,12 +314,12 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
-				input: 0.95,
-				output: 4,
-				cacheRead: 0.95,
+				input: 3,
+				output: 15,
+				cacheRead: 0.45,
 				cacheWrite: 0,
 			},
-			contextWindow: 262144,
+			contextWindow: 524288,
 			maxTokens: 65536,
 			compat: SYNTHETIC_COMPAT,
 		},
@@ -315,7 +331,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			cost: {
 				input: 0.45,
 				output: 3.6,
-				cacheRead: 0.45,
+				cacheRead: 0.09,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,
@@ -330,7 +346,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			cost: {
 				input: 0.1,
 				output: 0.1,
-				cacheRead: 0.1,
+				cacheRead: 0.02,
 				cacheWrite: 0,
 			},
 			contextWindow: 131072,
@@ -343,9 +359,9 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			reasoning: true,
 			input: ["text"],
 			cost: {
-				input: 1.4,
-				output: 4.4,
-				cacheRead: 1.4,
+				input: 1,
+				output: 3,
+				cacheRead: 0.16,
 				cacheWrite: 0,
 			},
 			contextWindow: 524288,
@@ -353,29 +369,29 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			...getSyntheticModelOverrides(GLM_5_2_MODEL_ID),
 		},
 		{
-			id: "hf:moonshotai/Kimi-K2.7-Code",
-			name: "moonshotai/Kimi-K2.7-Code",
+			id: KIMI_K3_MODEL_ID,
+			name: "moonshotai/Kimi-K3",
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
-				input: 0.95,
-				output: 4,
-				cacheRead: 0.95,
+				input: 3,
+				output: 15,
+				cacheRead: 0.45,
 				cacheWrite: 0,
 			},
-			contextWindow: 262144,
+			contextWindow: 524288,
 			maxTokens: 65536,
-			...getSyntheticModelOverrides(KIMI_K27_CODE_MODEL_ID),
+			...getSyntheticModelOverrides(KIMI_K3_MODEL_ID),
 		},
 		{
-			id: "hf:Qwen/Qwen3.6-27B",
+			id: QWEN_3_6_27B_MODEL_ID,
 			name: "Qwen/Qwen3.6-27B",
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
 				input: 0.45,
 				output: 3.6,
-				cacheRead: 0.45,
+				cacheRead: 0.09,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,
@@ -383,14 +399,14 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			...getSyntheticModelOverrides(QWEN_3_6_27B_MODEL_ID),
 		},
 		{
-			id: "hf:MiniMaxAI/MiniMax-M3",
+			id: MINIMAX_M3_MODEL_ID,
 			name: "MiniMaxAI/MiniMax-M3",
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
 				input: 0.6,
 				output: 1.2,
-				cacheRead: 0.6,
+				cacheRead: 0.12,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,
@@ -398,14 +414,14 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			...getSyntheticModelOverrides(MINIMAX_M3_MODEL_ID),
 		},
 		{
-			id: "hf:zai-org/GLM-4.7-Flash",
+			id: GLM_4_7_FLASH_MODEL_ID,
 			name: "zai-org/GLM-4.7-Flash",
 			reasoning: true,
 			input: ["text"],
 			cost: {
 				input: 0.1,
 				output: 0.5,
-				cacheRead: 0.1,
+				cacheRead: 0.02,
 				cacheWrite: 0,
 			},
 			contextWindow: 196608,
@@ -413,14 +429,14 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			...getSyntheticModelOverrides(GLM_4_7_FLASH_MODEL_ID),
 		},
 		{
-			id: "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			id: NEMOTRON_3_SUPER_MODEL_ID,
 			name: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
 			reasoning: true,
 			input: ["text"],
 			cost: {
 				input: 0.3,
 				output: 1,
-				cacheRead: 0.3,
+				cacheRead: 0.06,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,


### PR DESCRIPTION
## Summary

Synthetic launched **Kimi K3** and retired **Kimi-K2.7-Code** from the catalog the same day — earlier than the launch announcement suggested, which said K2.7-Code would stay online for a while. This refreshes the fallback catalog and the reasoning-effort table against a live authenticated pull of `/openai/v1/models`.

**Affected package:** `packages/pi-synthetic-provider`

> **Stack:** this PR → #29 (permalink thinking levels) → #30 (version bump to 1.2.2). The changelog here lands under `[Unreleased]`; the version bump ships in #30, following the #23 → #24 pattern.

## Kimi K3 thinking levels

Added `hf:moonshotai/Kimi-K3` with a `thinkingLevelMap` verified by live `reasoning_effort` probes against the chat completions endpoint:

| `reasoning_effort` | Result |
|---|---|
| `none` | 200, no reasoning emitted, clean content |
| `low` | 200, no reasoning emitted, clean content |
| `medium` | 200, reasoning emitted |
| `high` | 200, reasoning emitted |
| `max` | 200, reasoning emitted |

Mapping: `off` → `none`, `medium` → `medium`, `high` → `high`, `xhigh` → `max`.

Two notes on how this differs from the K2.7-Code entry it replaces:

- **`off` is now selectable.** K2.7-Code leaked raw `</think>` tags into message content at `none`/`low`, which is why #23 kept its `off` hidden. K3 returns clean content at both, so `off` maps to `none`.
- **`low`/`minimal` stay hidden.** The provider-side `low` value *disables* reasoning rather than reducing it, so mapping pi's `low` onto it would silently behave like `off` — the same treatment GLM-5.2, GLM-4.7-Flash, Qwen3.6-27B, and Nemotron already get.

## Catalog changes

- **Removed** `hf:moonshotai/Kimi-K2.7-Code` from fallback models and from `REASONING_OVERRIDES`; it is no longer in the catalog, so the override was dead weight that implied continued support.
- **Re-pointed** `syn:large:vision` from K2.7-Code to K3: 512K context (was 256K), $3.00/$15.00 (was $0.95/$4.00). Anyone pinned to the permalink picks this up automatically — which is the argument for permalinks over `hf:*` ids, and worth noting given `hf:moonshotai/Kimi-K2.7-Code` is now a dead id.
- **Refreshed** all fallback pricing and context windows against the live catalog. `syn:large:text` and GLM-5.2 drop to $1.00/$3.00 (were $1.40/$4.40).

## Bug fix: cache-read pricing

Fallback `cacheRead` was set equal to the **input** price rather than the catalog's `input_cache_reads` rate. Every fallback entry was affected. Taking `hf:zai-org/GLM-5.2`, which already existed in 1.2.1, cached reads were billed at $1.40 instead of $0.16 — a ~8.75× cost-tracking overstatement whenever the fallback path was in use. (K3 makes a poor example here: it wasn't in the 1.2.1 fallback at all, so its $0.45-vs-$3.00 gap was never actually charged.)

Live catalog discovery via `fetchSyntheticModels()` already read the correct field, so this only ever hit sessions that fell back (API unreachable, >3s timeout, or empty filtered catalog). A regression test now asserts `cacheRead < input` on every fallback entry.

## Testing

- `npm run check` (Biome lint + tsc typecheck) — clean
- `npm run test` — 160/160 passing across 16 files (159 at the merge base; +1 net)

Test updates: fallback id list and `thinkingLevelMap` expectations moved from K2.7-Code to K3 in both `helpers.test.ts` and `index.test.ts`, K2.7-Code added to the stale-id guard list, plus new assertions for K3's specs, the re-pointed `syn:large:vision`, and the cache-pricing invariant.

## Note

This branch has been force-pushed twice. The first push was cut from a stale local `main` (14 commits behind `origin/main`) and would have reverted the reasoning-effort work from #22/#23. The second dropped the version bump into #30 and restored `KIMI_K27_CODE_MODEL_ID` as a deprecated export — `extensions/` ships in the published package, so removing the named export would have broken deep imports and made a patch release indefensible. Review the current head rather than any earlier notification.



## Deprecated, not removed

`KIMI_K27_CODE_MODEL_ID` keeps its original value and stays exported, with a `@deprecated` tag pointing at `KIMI_K3_MODEL_ID`. The model itself is gone from the catalog, the fallback list, and the reasoning-override table — only the named export survives, so deep imports of `extensions/models.js` keep resolving.
