### PR TITLE
fix(pi-synthetic-provider): resolve thinking levels for syn:* permalinks

### DIFF
--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `syn:*` permalinks now receive their target model's reasoning-effort overrides during live catalog discovery, resolved through the row's `hugging_face_id`. Previously every permalink fell through to the shared compat with `supportsReasoningEffort: false`, so pi still displayed thinking levels — `reasoning: true` makes `off` through `high` selectable without a `thinkingLevelMap` — but the OpenAI-completions transport emitted no `reasoning_effort` for any of them. Every level, including `off`, silently left the model at Synthetic's server-side default. Live probes of all four permalink routes confirm an alias behaves exactly like its target, including `syn:small:text` inheriting GLM-4.7-Flash's HTTP 400 rejection of `max`.
+- `REASONING_OVERRIDES` is now a `Map`. As a plain object, a catalog id of `constructor`, `toString`, or similar resolved an inherited property to something truthy, which would then be spread into a model config.
+
+### Changed
+- Permalink resolution fails closed. An unknown, absent, or already-prefixed `hugging_face_id`, or a row whose explicit `supported_features` omits `reasoning`, yields the shared compat and emits no `reasoning_effort` at all — sending a value the backend rejects fails the entire request, which is worse than running at the default effort. The alias row's own capability list outranks its target's probed map.
+- `getSyntheticModelOverrides` takes an optional second `SyntheticModel` argument. Existing single-argument callers, including deep-import consumers, are unaffected.
+- Offline fallback permalinks deliberately keep the shared compat and no `thinkingLevelMap`: without a catalog row there is no way to know the alias's current target, and a stale map would be a guess that can fail every request. They still set `reasoning: true`, so pi continues to display levels `off` through `high` for them; those selections simply emit no `reasoning_effort`. This is now documented rather than implied by a test comment that mislabeled four reasoning models as "non-reasoning".
+- Live permalink resolution follows a re-point only when the new target is already in the verified override table. Those maps come from live probing and cannot be derived from `supported_features`, which reports that a model reasons but not which effort values it accepts. A re-point to an unprobed model leaves the permalink emitting no `reasoning_effort` until a release adds it.
+
 ### Added
 - Added `hf:moonshotai/Kimi-K3` to fallback models with thinking-level support, verified against live `reasoning_effort` probes: `off` → `none`, `medium` → `medium`, `high` → `high`, `xhigh` → `max`. Unlike Kimi-K2.7-Code, K3 returns clean content at `none` and `low` rather than leaking raw thinking tags, so `off` is selectable. `low`/`minimal` stay hidden because the provider-side `low` value disables reasoning outright, matching the treatment of the other reasoning models.
 

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -92,6 +92,16 @@ Prices are $ per million tokens, current as of 2026-07-28.
 
 The `syn:*` ids are permalinks that Synthetic re-points as models rotate, so configs using them survive model retirements — `syn:large:vision` moved from Kimi K2.7-Code to Kimi K3 in this release. The `hf:*` ids pin a specific model and break when it is retired.
 
+### Thinking levels on permalinks
+
+When models are discovered live, a `syn:*` permalink inherits its current target's thinking-level support, resolved from the catalog's `hugging_face_id`. Selecting `syn:large:vision` gives you the same levels as `hf:moonshotai/Kimi-K3`.
+
+This follows a re-point automatically **only when the new target is one of the models already in the verified override table**. Those maps come from live probing — which `reasoning_effort` values a model accepts, and which silently disable reasoning — and cannot be derived from the catalog, since `supported_features` reports only that a model reasons, not how it can be steered. If Synthetic re-points a permalink to a model this package has not probed, the permalink stops emitting `reasoning_effort` until a release adds it.
+
+That is the deliberate failure mode: when the target is unrecognized, or the catalog row declares no reasoning support, the permalink emits nothing rather than guessing. A rejected value fails the whole request, while omitting it simply runs at the server-side default.
+
+In the offline fallback list, permalinks never emit `reasoning_effort` at all — with no catalog row there is no way to know what the alias currently points at. Note that pi still *displays* thinking levels `off` through `high` for them, because those entries set `reasoning: true`; the selections just have no effect on the request.
+
 Kimi K3 is at beta launch pricing; Synthetic expects to lower it as engine optimization improves. Run `/synthetic-models` inside pi for the live catalog.
 
 ## API Key Priority

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -122,7 +122,12 @@ describe("pi-synthetic-provider helpers", () => {
 			expect(model?.thinkingLevelMap).toEqual(thinkingLevelMap);
 		}
 
-		// Non-reasoning fallbacks keep default compat
+		// These are NOT non-reasoning models — all four permalinks resolve to
+		// reasoning models and gpt-oss-120b advertises reasoning too. They keep the
+		// default compat deliberately: offline there is no catalog row naming the
+		// permalink's current target, and a stale effort map can fail every request
+		// with HTTP 400, which is worse than running at the server-side default.
+		// Live discovery resolves these through hugging_face_id; see index.test.ts.
 		for (const id of [
 			"syn:large:text",
 			"syn:small:text",

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -147,6 +147,143 @@ describe("pi-synthetic-provider", () => {
 		}
 	});
 
+	it("resolves syn:* permalink overrides through the catalog target", async () => {
+		const permalinks = [
+			["syn:large:text", "zai-org/GLM-5.2"],
+			["syn:small:text", "zai-org/GLM-4.7-Flash"],
+			["syn:large:vision", "moonshotai/Kimi-K3"],
+			["syn:small:vision", "Qwen/Qwen3.6-27B"],
+		] as const;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: permalinks.map(([id, huggingFaceId]) => ({
+						id,
+						name: id,
+						hugging_face_id: huggingFaceId,
+						always_on: true,
+						supported_features: ["tools", "reasoning"],
+						input_modalities: ["text"],
+						context_length: 524288,
+						max_output_length: 65536,
+						pricing: { prompt: "1", completion: "3" },
+					})),
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		for (const [id, huggingFaceId] of permalinks) {
+			const model = models.find((candidate) => candidate.id === id);
+			expect(model).toMatchObject({ reasoning: true, compat: { supportsReasoningEffort: true } });
+			expect(model?.thinkingLevelMap).toEqual(
+				REASONING_MODEL_MAPS[`hf:${huggingFaceId}` as keyof typeof REASONING_MODEL_MAPS],
+			);
+		}
+	});
+
+	it("leaves permalinks bare when the target cannot be resolved safely", async () => {
+		// Each row fails closed for a different reason: unknown target, absent
+		// target, an already-prefixed value, and an explicit non-reasoning
+		// capability list that outranks the target's probed map.
+		const rows = [
+			{ id: "syn:large:vision", hugging_face_id: "moonshotai/Kimi-K9", supported_features: ["tools", "reasoning"] },
+			{ id: "syn:large:text", supported_features: ["tools", "reasoning"] },
+			{ id: "syn:small:vision", hugging_face_id: "hf:Qwen/Qwen3.6-27B", supported_features: ["tools", "reasoning"] },
+			{ id: "syn:small:text", hugging_face_id: "zai-org/GLM-4.7-Flash", supported_features: ["tools"] },
+		];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: rows.map((row) => ({
+						...row,
+						name: row.id,
+						always_on: true,
+						input_modalities: ["text"],
+						context_length: 524288,
+						max_output_length: 65536,
+						pricing: { prompt: "1", completion: "3" },
+					})),
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		for (const row of rows) {
+			const model = models.find((candidate) => candidate.id === row.id);
+			expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
+			expect(model?.thinkingLevelMap).toBeUndefined();
+		}
+	});
+
+	it("does not alias a pinned hf: id through a mismatched catalog target", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: [
+						{
+							id: "hf:openai/gpt-oss-120b",
+							name: "openai/gpt-oss-120b",
+							hugging_face_id: "moonshotai/Kimi-K3",
+							always_on: true,
+							supported_features: ["tools", "reasoning"],
+							input_modalities: ["text"],
+							context_length: 131072,
+							max_output_length: 65536,
+							pricing: { prompt: "1", completion: "3" },
+						},
+					],
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		const model = models.find((candidate) => candidate.id === "hf:openai/gpt-oss-120b");
+		expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
+		expect(model?.thinkingLevelMap).toBeUndefined();
+	});
+
+	it("does not resolve inherited object keys as overrides", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					data: ["constructor", "toString", "__proto__"].map((id) => ({
+						id,
+						name: id,
+						always_on: true,
+						supported_features: ["tools", "reasoning"],
+						input_modalities: ["text"],
+						context_length: 131072,
+						max_output_length: 65536,
+						pricing: { prompt: "1", completion: "3" },
+					})),
+				}),
+			}),
+		);
+		const mockPi = createMockPi();
+		await syntheticProvider(mockPi as unknown as ExtensionAPI);
+
+		const models = mockPi.registerProvider.mock.calls[0]?.[1].models as ProviderModelConfig[];
+		for (const model of models) {
+			expect(model).toMatchObject({ compat: { supportsReasoningEffort: false } });
+			expect(model?.thinkingLevelMap).toBeUndefined();
+		}
+	});
+
 	it("keeps reasoning overrides enabled when the live catalog omits supported_features", async () => {
 		const liveModel = (id: string, name: string) => ({
 			id,

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -5,7 +5,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { SYNTHETIC_COMPAT, SYNTHETIC_MODELS_ENDPOINT } from "./config.js";
 import { parsePrice } from "./formatting.js";
-import type { SyntheticModelsResponse } from "./types.js";
+import type { SyntheticModel, SyntheticModelsResponse } from "./types.js";
 
 export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
 export const GLM_4_7_FLASH_MODEL_ID = "hf:zai-org/GLM-4.7-Flash";
@@ -143,20 +143,61 @@ const NEMOTRON_3_SUPER_REASONING_OVERRIDES = {
 	},
 } satisfies SyntheticModelOverrides;
 
-const REASONING_OVERRIDES: Record<string, SyntheticModelOverrides> = {
-	[GLM_5_2_MODEL_ID]: GLM_5_2_REASONING_OVERRIDES,
-	[GLM_4_7_FLASH_MODEL_ID]: GLM_4_7_FLASH_REASONING_OVERRIDES,
-	[KIMI_K3_MODEL_ID]: KIMI_K3_REASONING_OVERRIDES,
-	[QWEN_3_6_27B_MODEL_ID]: QWEN_3_6_27B_REASONING_OVERRIDES,
-	[MINIMAX_M3_MODEL_ID]: MINIMAX_M3_REASONING_OVERRIDES,
-	[NEMOTRON_3_SUPER_MODEL_ID]: NEMOTRON_3_SUPER_REASONING_OVERRIDES,
-};
+/**
+ * A `Map` rather than a plain object: `REASONING_OVERRIDES[modelId]` on an object
+ * literal resolves inherited keys, so a catalog id of `constructor` or `toString`
+ * would return a truthy non-override and be spread into a model config.
+ */
+const REASONING_OVERRIDES = new Map<string, SyntheticModelOverrides>([
+	[GLM_5_2_MODEL_ID, GLM_5_2_REASONING_OVERRIDES],
+	[GLM_4_7_FLASH_MODEL_ID, GLM_4_7_FLASH_REASONING_OVERRIDES],
+	[KIMI_K3_MODEL_ID, KIMI_K3_REASONING_OVERRIDES],
+	[QWEN_3_6_27B_MODEL_ID, QWEN_3_6_27B_REASONING_OVERRIDES],
+	[MINIMAX_M3_MODEL_ID, MINIMAX_M3_REASONING_OVERRIDES],
+	[NEMOTRON_3_SUPER_MODEL_ID, NEMOTRON_3_SUPER_REASONING_OVERRIDES],
+]);
 
-export function getSyntheticModelOverrides(modelId: string): SyntheticModelOverrides {
-	const override = REASONING_OVERRIDES[modelId];
-	if (override) {
-		return override;
+/** Synthetic's rotating permalink ids, e.g. `syn:large:vision`. */
+const PERMALINK_ID_PREFIX = "syn:";
+
+/**
+ * Resolve the reasoning-effort overrides for a catalog id.
+ *
+ * Pinned `hf:*` ids match the table directly. Permalink `syn:*` ids name no model
+ * of their own — Synthetic re-points them as the lineup rotates — so they resolve
+ * through the catalog row's `hugging_face_id`, which names the current target.
+ * Live probes confirm an alias request behaves exactly like a request to its
+ * target, including inheriting the target's rejection of unsupported values.
+ *
+ * Resolution fails closed. An unknown, absent, or already-prefixed target, or a
+ * row whose `supported_features` explicitly omits `reasoning`, yields the shared
+ * compat and no `reasoning_effort` is emitted at all. That is deliberate: sending
+ * a value the backend rejects fails the whole request with HTTP 400, which is
+ * strictly worse than running at the server-side default effort.
+ *
+ * The `model` parameter is optional so existing single-argument callers — the
+ * fallback catalog and any deep-import consumer — keep working unchanged.
+ */
+export function getSyntheticModelOverrides(modelId: string, model?: SyntheticModel): SyntheticModelOverrides {
+	const direct = REASONING_OVERRIDES.get(modelId);
+	if (direct) {
+		return direct;
 	}
+
+	if (model && modelId.startsWith(PERMALINK_ID_PREFIX)) {
+		// An explicit capability list that omits reasoning outranks the target's
+		// probed map: the alias row is the authority on what this route accepts.
+		const declaresNoReasoning =
+			Array.isArray(model.supported_features) && !model.supported_features.includes("reasoning");
+		const target = model.hugging_face_id;
+		if (!declaresNoReasoning && typeof target === "string" && target && !target.includes(":")) {
+			const aliased = REASONING_OVERRIDES.get(`hf:${target}`);
+			if (aliased) {
+				return aliased;
+			}
+		}
+	}
+
 	return { compat: SYNTHETIC_COMPAT };
 }
 
@@ -247,7 +288,7 @@ export async function fetchSyntheticModels(
 				},
 				contextWindow: model.context_length || 128000,
 				maxTokens: model.max_output_length || 32768,
-				...getSyntheticModelOverrides(modelId),
+				...getSyntheticModelOverrides(modelId, model),
 			});
 		}
 
@@ -275,6 +316,13 @@ export async function fetchSyntheticModels(
  *
  * Pricing format: $/million tokens. `cacheRead` tracks the catalog's
  * `input_cache_reads` rate, which is well below the input rate on every model.
+ *
+ * The `syn:*` entries deliberately carry no `thinkingLevelMap`. Offline there is
+ * no catalog row naming the permalink's current target, so any effort map here
+ * would be a guess that goes stale the moment Synthetic re-points the alias — and
+ * a wrong map fails every request with HTTP 400 rather than merely running at the
+ * default effort. Live discovery resolves permalinks properly via
+ * `hugging_face_id`; see `getSyntheticModelOverrides`.
  */
 export function getFallbackModels(): ProviderModelConfig[] {
 	return [


### PR DESCRIPTION
Re-lands #29 onto `main`. Identical content — this is a mechanics fix, not a new change.

#29 was reviewed and approved on its own merits, but it was squash-merged while its base branch `feat-synthetic-k3` still existed, so GitHub never retargeted it to `main` after #28 landed. It merged into `feat-synthetic-k3` instead. This PR cherry-picks that squashed commit onto `main`, where it applies cleanly: `main` at `f98a318` is content-identical to `feat-synthetic-k3` immediately before the #29 merge, verified with an empty `git diff`.

The full rationale, live probe results, and design discussion are in **#29** — please review there. Summary of what lands:

- `syn:*` permalinks resolve their target's reasoning-effort overrides via the catalog row's `hugging_face_id`. Previously they fell through to the shared compat with `supportsReasoningEffort: false`, so pi displayed thinking levels that emitted no `reasoning_effort` — controls that looked live but did nothing, including `off`.
- Resolution fails closed on unknown, absent, or already-prefixed targets, and when the row's `supported_features` explicitly omits `reasoning`.
- Offline fallback permalinks stay bare deliberately; a stale map can 400 every request.
- `REASONING_OVERRIDES` becomes a `Map`, closing a prototype-key hazard where a catalog id of `constructor` resolved to something truthy.
- `getSyntheticModelOverrides` gains an optional second parameter, so deep-import consumers are unaffected.

## Testing

- `npm run check` (Biome + tsc) — clean
- `npm run test` — 164/164 passing