### PR TITLE
feat(pi-claude-code-use)!: derive MCP aliases dynamically from getAllTools() (v2.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,6 +688,7 @@
       "version": "0.81.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.81.0.tgz",
       "integrity": "sha512-Fe6JYbW0CGVvmD4dwuFreynwZxlTElIMFRqYDl4llRiwfYZjjtAqbV1hY8MrdGqP15+FySBv5RGodOsHqlhvZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.81.0",
@@ -2640,19 +2641,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/@mistralai/mistralai": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
@@ -3700,6 +3688,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4332,12 +4321,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
-    },
     "node_modules/strnum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -4673,6 +4656,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -4682,18 +4666,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {
@@ -4732,17 +4704,10 @@
     },
     "packages/pi-claude-code-use": {
       "name": "@benvargas/pi-claude-code-use",
-      "version": "1.0.5",
+      "version": "2.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.5"
-      },
       "peerDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.74.0",
-        "@earendil-works/pi-ai": ">=0.74.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0",
-        "@earendil-works/pi-tui": ">=0.74.0",
-        "typebox": "*"
+        "@earendil-works/pi-coding-agent": ">=0.74.0"
       }
     },
     "packages/pi-cut-stack": {

--- a/packages/pi-claude-code-use/CHANGELOG.md
+++ b/packages/pi-claude-code-use/CHANGELOG.md
@@ -22,6 +22,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aliases are re-registered when the source tool's schema/description changes mid-session, and permanent reverse routes keep stale aliases resolving to their source tool after config changes.
 - Freshly registered aliases are tracked as auto-activated (Pi implicitly activates newly registered tools), so they are correctly deactivated for non-OAuth models and when their flat source tool is inactive.
 - `toolAliases` validation: entries with whitespace, over-length names, duplicate targets, collisions with other extensions' tools, or targets owned by a different flat tool are fully ignored with a warning (derivation applies instead).
+- Payload remapping now renames the flat tool entry (which always carries the source tool's current schema) instead of substituting the advertised alias stub, preserving the alias entry's `cache_control`. This keeps the advertised schema fresh even when a source tool re-registers with a new schema mid-turn.
+- Case-insensitive duplicate flat tool names are excluded from aliasing entirely (alias state is lowercase-keyed while Pi's execution lookup is exact-name, so aliasing either variant could misroute).
+- Alias activation sync records its managed baseline even on no-op syncs, so a user who later removes a flat tool but keeps its alias gets the alias correctly promoted to user-selected.
+- Same-name alias re-registrations (schema refresh) no longer flip a user-selected alias back to auto-managed.
 
 ### Known limitations
 - `getAllTools()` does not expose `promptSnippet`, `constrainedSampling`, or custom renderers, so aliases do not carry them (execution routing is unaffected; the flat tool's renderers apply once execution starts). Would be resolved upstream by expanding Pi's `ToolInfo`.

--- a/packages/pi-claude-code-use/CHANGELOG.md
+++ b/packages/pi-claude-code-use/CHANGELOG.md
@@ -7,6 +7,21 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-31
+
+### Changed
+- **Breaking:** replaced the hardcoded companion extension list (`pi-exa-mcp`, `pi-firecrawl`) and the jiti-based factory capture with dynamic alias registration driven by `pi.getAllTools()`. Every non-core flat tool in Pi's live registry now gets a deterministic MCP-style alias derived from its `sourceInfo` (e.g. `web_search_exa` → `mcp__exa_mcp__web_search_exa`), including tools that other extensions register from lifecycle hooks (e.g. `pi-web-providers`), which the previous capture approach missed.
+- Alias tools are now schema-only stubs built from `getAllTools()` metadata (parameters, description, prompt guidelines). Managed alias calls were already rewritten back to their flat source names at `message_end` before execution, so the captured duplicate `execute` was never used; the stub throws if that rewrite is ever bypassed.
+- Derived alias names resolve collisions deterministically with numeric suffixes and respect Anthropic's 128-char tool name limit. Derived names never shadow existing tools (including real MCP tools from other extensions).
+- User-configured `toolAliases` entries now act as overrides on top of automatic derivation and must be `mcp__`-prefixed (invalid entries are ignored with a warning).
+- Removed the `@mariozechner/jiti` dependency and the `pi-ai`/`pi-agent-core`/`pi-tui`/`typebox` peer dependencies; only `@earendil-works/pi-coding-agent` remains.
+
+### Added
+- `PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS=1` environment variable to disable automatic alias derivation while keeping user-configured aliases.
+
+### Migration notes
+- Previously curated alias names (`mcp__exa__web_search`, `mcp__firecrawl__scrape`, ...) change to derived names (`mcp__exa_mcp__web_search_exa`, `mcp__firecrawl__firecrawl_scrape`, ...). Session files persist flat tool names, so resumed sessions are unaffected. To keep the old names, add them as `toolAliases` overrides in `pi-claude-code-use.json`.
+
 ## [1.0.5] - 2026-07-16
 
 ### Fixed

--- a/packages/pi-claude-code-use/CHANGELOG.md
+++ b/packages/pi-claude-code-use/CHANGELOG.md
@@ -14,10 +14,17 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alias tools are now schema-only stubs built from `getAllTools()` metadata (parameters, description, prompt guidelines). Managed alias calls were already rewritten back to their flat source names at `message_end` before execution, so the captured duplicate `execute` was never used; the stub throws if that rewrite is ever bypassed.
 - Derived alias names resolve collisions deterministically with numeric suffixes and respect Anthropic's 128-char tool name limit. Derived names never shadow existing tools (including real MCP tools from other extensions).
 - User-configured `toolAliases` entries now act as overrides on top of automatic derivation and must be `mcp__`-prefixed (invalid entries are ignored with a warning).
-- Removed the `@mariozechner/jiti` dependency and the `pi-ai`/`pi-agent-core`/`pi-tui`/`typebox` peer dependencies; only `@earendil-works/pi-coding-agent` remains.
+- Removed the `@mariozechner/jiti` dependency and the `pi-ai`/`pi-agent-core`/`pi-tui`/`typebox` peer dependencies; only `@earendil-works/pi-coding-agent` remains, with the floor raised to `>=0.77.0` (first release exposing `promptGuidelines` in `ToolInfo`).
 
 ### Added
 - `PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS=1` environment variable to disable automatic alias derivation while keeping user-configured aliases.
+- An additional alias pass during `before_provider_request` so tools registered by other extensions' `before_agent_start` handlers (running after this extension's) are aliased in-payload on their first turn.
+- Aliases are re-registered when the source tool's schema/description changes mid-session, and permanent reverse routes keep stale aliases resolving to their source tool after config changes.
+- Freshly registered aliases are tracked as auto-activated (Pi implicitly activates newly registered tools), so they are correctly deactivated for non-OAuth models and when their flat source tool is inactive.
+- `toolAliases` validation: entries with whitespace, over-length names, duplicate targets, collisions with other extensions' tools, or targets owned by a different flat tool are fully ignored with a warning (derivation applies instead).
+
+### Known limitations
+- `getAllTools()` does not expose `promptSnippet`, `constrainedSampling`, or custom renderers, so aliases do not carry them (execution routing is unaffected; the flat tool's renderers apply once execution starts). Would be resolved upstream by expanding Pi's `ToolInfo`.
 
 ### Migration notes
 - Previously curated alias names (`mcp__exa__web_search`, `mcp__firecrawl__scrape`, ...) change to derived names (`mcp__exa_mcp__web_search_exa`, `mcp__firecrawl__firecrawl_scrape`, ...). Session files persist flat tool names, so resumed sessions are unaffected. To keep the old names, add them as `toolAliases` overrides in `pi-claude-code-use.json`.

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -72,7 +72,9 @@ Anthropic's OAuth subscription endpoint refuses flat-named custom tools but acce
    - directory-based extensions → the nearest non-generic directory name (skipping `extensions`, `src`, `dist`, `lib`, `build`, `out`)
    A leading `pi-` prefix is stripped and the segment is sanitized to `[a-z0-9_]`.
 3. The alias is `mcp__<server>__<tool>` (sanitized, capped at Anthropic's 128-char limit). Name collisions are resolved deterministically with numeric suffixes (`_2`, `_3`, ...) in sorted flat-name order; derived names never shadow an existing tool.
-4. A schema-only alias tool is registered carrying the source tool's parameter schema, description, and prompt guidelines. Its `execute` is a stub: when the assistant calls a managed alias, `pi-claude-code-use` rewrites the finalized `toolCall` back to the original flat name during `message_end`, before Pi resolves execution, so the source extension's original `execute` closure and state always run.
+4. A schema-only alias tool is registered carrying the source tool's parameter schema, description, and prompt guidelines. Its `execute` is a stub: when the assistant calls a managed alias, `pi-claude-code-use` rewrites the finalized `toolCall` back to the original flat name during `message_end`, before Pi resolves execution, so the source extension's original `execute` closure and state always run. Aliases are re-registered if the source tool's schema changes mid-session, and every alias keeps a permanent reverse route so stale aliases (after config changes) still resolve to their source tool.
+
+Alias passes run at `session_start`, `before_agent_start`, and `before_provider_request` (OAuth requests only). The last pass catches tools that another extension registers from its own `before_agent_start` handler after this extension's handler already ran, so those tools are aliased in-payload on their first turn instead of the second.
 
 Examples with the companion extensions from this monorepo installed via npm:
 
@@ -99,7 +101,7 @@ Derived names are deterministic but mechanical. To choose specific alias names (
 }
 ```
 
-Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; the alias must be in the form `mcp__<namespace>__<tool>` (entries without the `mcp__` prefix are ignored with a warning).
+Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; the alias must be in the form `mcp__<namespace>__<tool>`. Entries are validated and invalid ones are fully ignored with a warning (derivation applies instead): the alias must be `mcp__`-prefixed, trimmed, at most 128 characters, not already used by another entry, not the name of another extension's tool, and not an alias this extension already registered for a different flat tool.
 
 User-configured aliases override automatic derivation for that flat tool. They are otherwise treated the same as derived aliases: Anthropic sees the MCP-style name, but managed alias calls are canonicalized back to the flat source tool before local execution. MCP-style tools that are provided directly by another extension are not rewritten unless `pi-claude-code-use` registered that same alias.
 
@@ -130,6 +132,16 @@ Examples:
 - `mcp__mytools__lookup_customer`
 
 That said, flat-named tools no longer require any special handling: `pi-claude-code-use` automatically derives and registers an MCP-style alias for every non-core flat tool it finds in Pi's registry, including tools registered from lifecycle hooks. Registering directly under an MCP-style name simply avoids the aliasing layer entirely.
+
+## Known Limitations
+
+Pi's `getAllTools()` exposes each tool's name, description, parameter schema, prompt guidelines, and source metadata — but not the full `ToolDefinition`. As a result, alias tools do not carry:
+
+- `promptSnippet` -- the source tool's one-line entry in Pi's "Available tools" system prompt section keeps the flat name.
+- `constrainedSampling` -- provider-side strict-schema sampling configured on the source tool does not apply to the alias.
+- `renderCall` / `renderResult` / `renderShell` -- while a call is streaming, an aliased tool renders with Pi's generic renderer; execution itself is still routed to (and rendered by) the flat tool.
+
+These are display/metadata-level gaps; execution correctness is unaffected. They would be resolved upstream if Pi expanded `ToolInfo` or exposed `getToolDefinition()` on the extension API.
 
 ## Notes
 

--- a/packages/pi-claude-code-use/README.md
+++ b/packages/pi-claude-code-use/README.md
@@ -14,10 +14,10 @@ When Pi is using Anthropic OAuth, this extension intercepts outbound API request
   - `pi packages` → `cli packages`
   Preserves Pi's original `system[]` structure, `cache_control` metadata, and non-text blocks.
 - **Tool filtering** -- passes through core Claude Code tools, Anthropic-native typed tools (e.g. `web_search`), and any tool prefixed with `mcp__`. Unknown flat-named tools are filtered out.
-- **Companion tool remapping** -- renames known companion extension tools from their flat names to MCP-style aliases (e.g. `web_search_exa` becomes `mcp__exa__web_search`). Duplicate flat entries are removed after remapping.
-- **tool_choice remapping** -- if `tool_choice` references a flat companion name that was remapped, the reference is updated to the MCP alias. If it references a tool that was filtered out, `tool_choice` is removed from the payload.
-- **Message history rewriting** -- `tool_use` blocks in conversation history that reference flat companion names are rewritten to their MCP aliases so the model sees consistent tool names across the conversation.
-- **Companion alias registration** -- at session start and before each agent turn, discovers loaded companion extensions, captures their tool definitions via a jiti-based shim, and registers MCP-alias copies so Anthropic sees Claude Code-compatible names.
+- **Automatic tool remapping** -- renames flat extension tool names to derived MCP-style aliases (e.g. `web_search_exa` becomes `mcp__exa_mcp__web_search_exa`). Duplicate flat entries are removed after remapping.
+- **tool_choice remapping** -- if `tool_choice` references a flat name that was remapped, the reference is updated to the MCP alias. If it references a tool that was filtered out, `tool_choice` is removed from the payload.
+- **Message history rewriting** -- `tool_use` blocks in conversation history that reference remapped flat names are rewritten to their MCP aliases so the model sees consistent tool names across the conversation.
+- **Dynamic alias registration** -- at session start and before each agent turn, reads Pi's live tool registry via `getAllTools()` and registers a schema-only MCP alias for every non-core flat tool, from any extension. This includes tools that other extensions register from lifecycle hooks (e.g. `pi-web-providers`), with no hardcoded extension list to maintain.
 - **Managed tool-call unaliasing** -- when the model calls an MCP alias registered by this extension, rewrites the finalized `toolCall` name back to the original flat tool name during `message_end`, before Pi resolves execution. Direct MCP tools from other extensions are left untouched.
 - **Alias activation tracking** -- auto-activates MCP aliases when their flat counterpart is active under Anthropic OAuth. Tracks provenance (auto-managed vs user-selected) so that disabling OAuth only removes auto-activated aliases, preserving any the user explicitly enabled.
 
@@ -52,6 +52,7 @@ No extra configuration is required.
 |---|---|
 | `PI_CLAUDE_CODE_USE_DEBUG_LOG` | Set to a file path to enable debug logging. Writes two JSON entries per Anthropic OAuth request: one with `"stage": "before"` (the original payload from Pi) and one with `"stage": "after"` (the transformed payload sent to Anthropic). |
 | `PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER` | Set to `1` to disable tool filtering. System prompt rewriting still applies, but all tools pass through unchanged. Useful for debugging whether a tool-filtering issue is causing a problem. |
+| `PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS` | Set to `1` to disable automatic alias derivation. Only user-configured `toolAliases` are registered; other flat-named tools are filtered out on Anthropic OAuth requests as before. |
 
 Example:
 
@@ -59,30 +60,35 @@ Example:
 PI_CLAUDE_CODE_USE_DEBUG_LOG=/tmp/pi-claude-debug.log pi -e /path/to/extensions/index.ts --model anthropic/claude-sonnet-4-20250514
 ```
 
-## Companion Tool Aliases
+## Automatic Tool Aliases
 
-When these companion extensions from this monorepo are loaded alongside `pi-claude-code-use`, MCP aliases are automatically registered and remapped:
+Anthropic's OAuth subscription endpoint refuses flat-named custom tools but accepts any name shaped like `mcp__<server>__<tool>` (it does not validate that a real MCP server exists). Instead of maintaining a hardcoded list of known extensions, `pi-claude-code-use` derives an MCP alias for every non-core flat tool in Pi's live registry:
 
-| Flat name | MCP alias |
+1. At `session_start` and `before_agent_start`, it calls `pi.getAllTools()` and inspects each tool's `sourceInfo`.
+2. The `<server>` segment is derived from where the tool came from, in priority order:
+   - Pi built-in / SDK synthetic sources → `pi`
+   - npm installs → the unscoped package name from the `node_modules` path (e.g. `@benvargas/pi-exa-mcp` → `exa_mcp`)
+   - single-file extensions → the file stem (e.g. `my-tool.ts` → `my_tool`)
+   - directory-based extensions → the nearest non-generic directory name (skipping `extensions`, `src`, `dist`, `lib`, `build`, `out`)
+   A leading `pi-` prefix is stripped and the segment is sanitized to `[a-z0-9_]`.
+3. The alias is `mcp__<server>__<tool>` (sanitized, capped at Anthropic's 128-char limit). Name collisions are resolved deterministically with numeric suffixes (`_2`, `_3`, ...) in sorted flat-name order; derived names never shadow an existing tool.
+4. A schema-only alias tool is registered carrying the source tool's parameter schema, description, and prompt guidelines. Its `execute` is a stub: when the assistant calls a managed alias, `pi-claude-code-use` rewrites the finalized `toolCall` back to the original flat name during `message_end`, before Pi resolves execution, so the source extension's original `execute` closure and state always run.
+
+Examples with the companion extensions from this monorepo installed via npm:
+
+| Flat name | Derived MCP alias |
 |---|---|
-| `web_search_exa` | `mcp__exa__web_search` |
-| `get_code_context_exa` | `mcp__exa__get_code_context` |
-| `firecrawl_scrape` | `mcp__firecrawl__scrape` |
-| `firecrawl_map` | `mcp__firecrawl__map` |
-| `firecrawl_search` | `mcp__firecrawl__search` |
+| `web_search_exa` | `mcp__exa_mcp__web_search_exa` |
+| `get_code_context_exa` | `mcp__exa_mcp__get_code_context_exa` |
+| `firecrawl_scrape` | `mcp__firecrawl__firecrawl_scrape` |
 
-### How companion discovery works
+Because aliases are re-derived from the live registry on every agent turn, tools registered by other extensions **from lifecycle hooks** (such as `pi-web-providers`' managed `web_search`/`web_contents`/`web_answer`/`web_research` tools) are picked up automatically.
 
-The extension identifies companion tools by matching `sourceInfo` metadata that Pi attaches to each registered tool:
-
-1. **baseDir match** -- if the tool's `sourceInfo.baseDir` directory name matches the companion's directory name (e.g. `pi-exa-mcp`).
-2. **Path match** -- if the tool's `sourceInfo.path` contains the companion's scoped package name (e.g. `@benvargas/pi-exa-mcp`) or directory name as a path segment. This handles npm installs, git clones, and monorepo layouts where `baseDir` points to the repo root rather than the individual package.
-
-Once a companion tool is identified, its extension factory is loaded via jiti into a capture shim to obtain the full tool definition, which is then re-registered under the MCP alias name. Those alias copies are model-facing compatibility shims; when the assistant actually calls one of these managed aliases, `pi-claude-code-use` rewrites the finalized `toolCall` back to the original flat name before Pi executes the tool. This preserves the source extension's original `execute` closure and state.
+Session files always persist flat tool names (alias calls are rewritten back before persistence), so derived alias names can change across versions without corrupting resumed sessions.
 
 ## User-Defined Tool Aliases
 
-To register MCP-style aliases for flat-named tools from other installed extensions, create `~/.pi/agent/extensions/pi-claude-code-use.json` (global) or `<project>/.pi/extensions/pi-claude-code-use.json` (project). Schema:
+Derived names are deterministic but mechanical. To choose specific alias names (for example, ones that mirror a real MCP server's naming), create `~/.pi/agent/extensions/pi-claude-code-use.json` (global) or `<project>/.pi/extensions/pi-claude-code-use.json` (project). Schema:
 
 ```json
 {
@@ -93,15 +99,15 @@ To register MCP-style aliases for flat-named tools from other installed extensio
 }
 ```
 
-Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; choose an MCP alias in the form `mcp__<namespace>__<tool>`.
+Each entry maps an existing flat Pi tool name to the MCP-style name Anthropic should see. Use the flat tool name exactly as the source extension registers it; the alias must be in the form `mcp__<namespace>__<tool>` (entries without the `mcp__` prefix are ignored with a warning).
 
-Aliases registered through this config are treated the same as the built-in companion aliases: Anthropic sees the MCP-style name, but managed alias calls are canonicalized back to the flat source tool before local execution. MCP-style tools that are provided directly by another extension are not rewritten unless `pi-claude-code-use` registered that same alias.
+User-configured aliases override automatic derivation for that flat tool. They are otherwise treated the same as derived aliases: Anthropic sees the MCP-style name, but managed alias calls are canonicalized back to the flat source tool before local execution. MCP-style tools that are provided directly by another extension are not rewritten unless `pi-claude-code-use` registered that same alias.
 
-The project file replaces the global file as a whole. Set `"toolAliases": []` in the project file to disable inherited globals.
+The project file replaces the global file as a whole. Set `"toolAliases": []` in the project file to disable inherited globals (automatic derivation still applies unless `PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS=1`).
 
 ## Core Tools Allowlist
 
-The following tool names always pass through filtering (case-insensitive). This list mirrors Pi core's `claudeCodeTools` in `packages/ai/src/providers/anthropic.ts`:
+The following tool names always pass through filtering (case-insensitive) and are never aliased. This list mirrors Pi core's `claudeCodeTools` in `packages/ai/src/api/anthropic-messages.ts`:
 
 `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode`, `KillShell`, `NotebookEdit`, `Skill`, `Task`, `TaskOutput`, `TodoWrite`, `WebFetch`, `WebSearch`
 
@@ -123,11 +129,11 @@ Examples:
 - `mcp__firecrawl__scrape`
 - `mcp__mytools__lookup_customer`
 
-If an extension keeps a flat legacy name for non-Anthropic use, it can also register an MCP-style alias alongside it. `pi-claude-code-use` already does this centrally for the known companion tools in this repo, but unknown non-MCP tool names will still be filtered out on Anthropic OAuth requests.
+That said, flat-named tools no longer require any special handling: `pi-claude-code-use` automatically derives and registers an MCP-style alias for every non-core flat tool it finds in Pi's registry, including tools registered from lifecycle hooks. Registering directly under an MCP-style name simply avoids the aliasing layer entirely.
 
 ## Notes
 
 - The extension activates for all Anthropic OAuth requests regardless of model, rather than using a fixed model allowlist.
 - Non-OAuth Anthropic usage (API key auth) is left unchanged.
-- In practice, unknown non-MCP extension tools were the remaining trigger for Anthropic's extra-usage classification, so this package keeps core tools, keeps MCP-style tools, auto-aliases the known companion tools above, and filters the rest.
+- In practice, unknown non-MCP extension tools were the remaining trigger for Anthropic's extra-usage classification, so this package keeps core tools, keeps MCP-style tools, auto-aliases every other flat tool, and filters anything left over (aliases whose flat tool is inactive, and flat tools when auto-aliasing is disabled).
 - Pi may show its built-in OAuth subscription warning banner even when the request path works correctly. That banner is UI logic in Pi, not a signal that the upstream request is being billed as extra usage.

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -78,6 +78,8 @@ describe("pi-claude-code-use", () => {
 		_test.registeredMcpAliases.clear();
 		_test.autoActivatedAliases.clear();
 		_test.aliasAssignments.clear();
+		_test.registeredAliasRoutes.clear();
+		_test.aliasSourceMeta.clear();
 		_test.setLastManagedToolList(undefined);
 		_test.refreshAliasMap([]);
 	});
@@ -682,6 +684,86 @@ describe("pi-claude-code-use", () => {
 			expect(_test.FLAT_TO_MCP.get("web_search")).toBe("mcp__web_providers__web_search");
 		});
 
+		it("marks freshly registered aliases as auto-activated (pi auto-activates new tools)", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+			]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			// Pi's registerTool implicitly activates the new alias; provenance must
+			// record it as auto-managed so a non-OAuth sync removes it.
+			expect(_test.autoActivatedAliases.has("mcp__exa_mcp__web_search_exa")).toBe(true);
+
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+				mockTool("mcp__exa_mcp__web_search_exa"),
+			]);
+			pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
+			_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+			expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa"]);
+		});
+
+		it("re-registers an alias when the source tool's schema changes", () => {
+			const pi = createMockPi();
+			const path = "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts";
+			const v1 = mockTool("web_search_exa", { path, description: "v1" });
+			pi.getAllTools.mockReturnValue([v1]);
+			registerAliasesIsolated(pi, tempDir);
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+
+			// Same metadata: no re-registration.
+			registerAliasesIsolated(pi, tempDir);
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+
+			// Source extension re-registered the tool with new metadata.
+			const v2 = mockTool("web_search_exa", { path, description: "v2" });
+			pi.getAllTools.mockReturnValue([v2]);
+			registerAliasesIsolated(pi, tempDir);
+			expect(pi.registerTool).toHaveBeenCalledTimes(2);
+			expect(pi.registerTool).toHaveBeenLastCalledWith(
+				expect.objectContaining({ name: "mcp__exa_mcp__web_search_exa", description: "v2" }),
+			);
+		});
+
+		it("copies parameters and promptGuidelines onto the alias by identity", () => {
+			const pi = createMockPi();
+			const parameters = { type: "object", properties: { q: { type: "string" } } };
+			const promptGuidelines = ["Prefer batched queries"];
+			pi.getAllTools.mockReturnValue([
+				{
+					...mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+					parameters: parameters as never,
+					promptGuidelines,
+				},
+			]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			const def = pi.registerTool.mock.calls[0]?.[0] as { parameters: unknown; promptGuidelines?: unknown };
+			expect(def.parameters).toBe(parameters);
+			expect(def.promptGuidelines).toBe(promptGuidelines);
+		});
+
+		it("skips case-insensitive duplicate flat tool names deterministically", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("MyTool", { path: "/x/node_modules/pi-ext-a/index.js" }),
+					mockTool("mytool", { path: "/y/node_modules/pi-ext-b/index.js" }),
+				]);
+
+				registerAliasesIsolated(pi, tempDir);
+
+				expect(pi.registerTool).toHaveBeenCalledTimes(1);
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("case-insensitive duplicate"));
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
 		it("registers alias stubs whose execute throws instead of shadow-executing", async () => {
 			const pi = createMockPi();
 			pi.getAllTools.mockReturnValue([
@@ -962,8 +1044,17 @@ describe("pi-claude-code-use", () => {
 	async function getProviderRequestHandler(pi: ReturnType<typeof createMockPi>) {
 		await piClaudeCodeUse(pi as unknown as ExtensionAPI);
 		const hookCall = pi.on.mock.calls.find((c: unknown[]) => c[0] === "before_provider_request");
-		return hookCall?.[1] as (event: { payload: unknown }, ctx: Record<string, unknown>) => unknown;
+		const handler = hookCall?.[1] as (event: { payload: unknown }, ctx: Record<string, unknown>) => unknown;
+		// The handler refreshes aliases from config; isolate from any real user config.
+		const isolatedDir = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		vi.stubEnv("PI_CODING_AGENT_DIR", join(isolatedDir, "agent"));
+		return (event: { payload: unknown }, ctx: Record<string, unknown>) =>
+			handler(event, { cwd: join(isolatedDir, "project"), ...ctx });
 	}
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
 
 	it("transforms payload when model is anthropic OAuth", async () => {
 		const pi = createMockPi();
@@ -974,7 +1065,7 @@ describe("pi-claude-code-use", () => {
 			modelRegistry: { isUsingOAuth: () => true },
 		};
 
-		const result = handler(
+		const result = await handler(
 			{
 				payload: {
 					system: "ask about pi itself",
@@ -992,6 +1083,42 @@ describe("pi-claude-code-use", () => {
 		const p = result as Record<string, unknown>;
 		expect(p.system).toBe("ask about the cli itself");
 		expect((p.tools as { name: string }[]).map((t) => t.name)).toEqual(["Read"]);
+	});
+
+	it("aliases late-registered flat tools in-payload on the first turn", async () => {
+		const pi = createMockPi();
+		const handler = await getProviderRequestHandler(pi);
+
+		// Simulate a companion extension whose before_agent_start ran AFTER ours
+		// and registered web_search: it is active (in the payload) but no alias
+		// pass has seen it yet.
+		pi.getAllTools.mockReturnValue([
+			mockTool("read"),
+			mockTool("web_search", { path: "/x/node_modules/pi-web-providers/dist/index.js" }),
+		]);
+
+		const ctx = {
+			model: { provider: "anthropic", id: "claude-opus-4-6" },
+			modelRegistry: { isUsingOAuth: () => true },
+		};
+
+		const result = (await handler(
+			{
+				payload: {
+					tools: [
+						{ name: "Read", description: "Read", input_schema: {} },
+						{ name: "web_search", description: "Managed web search", input_schema: {} },
+					],
+					messages: [],
+				},
+			},
+			ctx,
+		)) as Record<string, unknown>;
+
+		// The alias gets registered during the request hook...
+		expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__web_providers__web_search" }));
+		// ...and the flat tool is renamed in-payload even though the alias was not advertised.
+		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual(["Read", "mcp__web_providers__web_search"]);
 	});
 
 	it("returns undefined for non-anthropic models", async () => {
@@ -1118,21 +1245,128 @@ describe("pi-claude-code-use", () => {
 			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa__web_search");
 		});
 
-		it("ignores user aliases that are not mcp__-prefixed", () => {
+		it("ignores user aliases that are not mcp__-prefixed and keeps the derived alias", () => {
 			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			try {
 				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "not_an_mcp_name"]] }));
 
 				const pi = createMockPi();
-				pi.getAllTools.mockReturnValue([mockTool("subagent")]);
+				pi.getAllTools.mockReturnValue([mockTool("subagent", { path: "/x/node_modules/pi-sub/index.js" })]);
 
 				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
 
 				expect(pi.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "not_an_mcp_name" }));
 				expect(warn).toHaveBeenCalledWith(expect.stringContaining('alias must start with "mcp__"'));
+				// The invalid entry must not poison the alias maps: the derived alias wins.
+				expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__sub__subagent");
+				expect(_test.MCP_TO_FLAT.has("not_an_mcp_name")).toBe(false);
 			} finally {
 				warn.mockRestore();
 			}
+		});
+
+		it("rejects user aliases that collide with another extension's MCP tool", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__real__tool"]] }));
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("subagent", { path: "/x/node_modules/pi-sub/index.js" }),
+					mockTool("mcp__real__tool"),
+				]);
+
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("already taken by another extension's tool"));
+				// The foreign tool must not be routed to; derivation applies instead.
+				expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__sub__subagent");
+				expect(_test.MCP_TO_FLAT.has("mcp__real__tool")).toBe(false);
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
+		it("rejects duplicate override targets (first wins)", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				writeFileSync(
+					projectConfigPath,
+					JSON.stringify({
+						toolAliases: [
+							["tool_a", "mcp__shared__name"],
+							["tool_b", "mcp__shared__name"],
+						],
+					}),
+				);
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("tool_a", { path: "/x/node_modules/pi-a/index.js" }),
+					mockTool("tool_b", { path: "/x/node_modules/pi-b/index.js" }),
+				]);
+
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("already used by another toolAliases entry"));
+				expect(_test.FLAT_TO_MCP.get("tool_a")).toBe("mcp__shared__name");
+				expect(_test.MCP_TO_FLAT.get("mcp__shared__name")).toBe("tool_a");
+				// tool_b falls back to derivation.
+				expect(_test.FLAT_TO_MCP.get("tool_b")).toBe("mcp__b__tool_b");
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
+		it("rejects overrides with surrounding whitespace or over-length names", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				writeFileSync(
+					projectConfigPath,
+					JSON.stringify({
+						toolAliases: [
+							["tool_a", " mcp__padded__name"],
+							["tool_b", `mcp__long__${"x".repeat(130)}`],
+						],
+					}),
+				);
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([]);
+
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("surrounding whitespace"));
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("exceeds 128 characters"));
+				expect(_test.FLAT_TO_MCP.size).toBe(0);
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
+		it("reverts to the derived alias when an override is removed (auto-aliasing enabled)", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+			]);
+
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["web_search_exa", "mcp__exa__web_search"]] }));
+			_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa__web_search");
+
+			// Remove the override: automatic derivation must take over again.
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
+			_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa_mcp__web_search_exa");
+
+			// The stale override alias keeps a reverse route for unaliasing.
+			const msg = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "s", name: "mcp__exa__web_search", arguments: {} }],
+			};
+			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+			expect(out).toBeDefined();
+			expect((out?.content[0] as { name: string }).name).toBe("web_search_exa");
 		});
 
 		it("keeps user alias mappings for flat tools that are not in the registry", () => {

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -10,10 +10,10 @@ import piClaudeCodeUse, { _test } from "../extensions/index.js";
 // ============================================================================
 
 /** Build a minimal ToolInfo-compatible object for test mocks. */
-function mockTool(name: string, sourceOverrides?: { baseDir?: string; path?: string }) {
+function mockTool(name: string, sourceOverrides?: { baseDir?: string; path?: string; description?: string }) {
 	return {
 		name,
-		description: "",
+		description: sourceOverrides?.description ?? "",
 		parameters: {} as never,
 		sourceInfo: {
 			path: sourceOverrides?.path ?? "",
@@ -61,6 +61,14 @@ function getRegisteredHandler(pi: ReturnType<typeof createMockPi>, eventName: st
 	return call?.[1] as (event: unknown, ctx: Record<string, unknown>) => Promise<unknown>;
 }
 
+/** Run registerMcpAliases against an isolated (empty) config location. */
+function registerAliasesIsolated(pi: ReturnType<typeof createMockPi>, tempDir: string) {
+	_test.registerMcpAliases(pi as unknown as ExtensionAPI, {
+		cwd: join(tempDir, "project"),
+		agentDir: join(tempDir, "agent"),
+	});
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -69,6 +77,7 @@ describe("pi-claude-code-use", () => {
 	beforeEach(() => {
 		_test.registeredMcpAliases.clear();
 		_test.autoActivatedAliases.clear();
+		_test.aliasAssignments.clear();
 		_test.setLastManagedToolList(undefined);
 		_test.refreshAliasMap([]);
 	});
@@ -84,6 +93,7 @@ describe("pi-claude-code-use", () => {
 		expect(pi.on).toHaveBeenCalledWith("session_start", expect.any(Function));
 		expect(pi.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
 		expect(pi.on).toHaveBeenCalledWith("before_provider_request", expect.any(Function));
+		expect(pi.on).toHaveBeenCalledWith("message_end", expect.any(Function));
 		expect(pi.registerProvider).not.toHaveBeenCalled();
 	});
 
@@ -124,14 +134,6 @@ describe("pi-claude-code-use", () => {
 			vi.unstubAllEnvs();
 			rmSync(tempParent, { recursive: true, force: true });
 		}
-	});
-
-	it("does not register alias tools when no companion source tools are loaded", async () => {
-		const pi = createMockPi();
-		pi.getAllTools.mockReturnValue([mockTool("read")]);
-		await piClaudeCodeUse(pi as unknown as ExtensionAPI);
-
-		expect(pi.registerTool).not.toHaveBeenCalled();
 	});
 
 	// ----------------------------------------------------------------
@@ -236,13 +238,14 @@ describe("pi-claude-code-use", () => {
 		expect(toolIds).toEqual(["Read", "web_search", "mcp__custom__lookup"]);
 	});
 
-	it("renames known companion tools to MCP aliases when alias is advertised", () => {
+	it("renames aliased flat tools to MCP aliases when alias is advertised", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				tools: [
 					{ name: "web_search_exa", description: "Flat", input_schema: {} },
 					{
-						name: "mcp__exa__web_search",
+						name: "mcp__exa_mcp__web_search_exa",
 						description: "Alias",
 						input_schema: {},
 						cache_control: { type: "ephemeral", ttl: "1h" },
@@ -253,7 +256,7 @@ describe("pi-claude-code-use", () => {
 			false,
 		);
 
-		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual(["mcp__exa__web_search"]);
+		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual(["mcp__exa_mcp__web_search_exa"]);
 		expect(result.tools).toEqual([
 			expect.objectContaining({
 				description: "Alias",
@@ -262,7 +265,8 @@ describe("pi-claude-code-use", () => {
 		]);
 	});
 
-	it("filters companion tools when MCP alias is not in the tool list", () => {
+	it("filters aliased flat tools when the MCP alias is not in the tool list", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				tools: [{ name: "web_search_exa", description: "Orphan", input_schema: {} }],
@@ -275,11 +279,12 @@ describe("pi-claude-code-use", () => {
 	});
 
 	it("passes all tools through unchanged when filter is disabled", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				tools: [
 					{ name: "web_search_exa", description: "Flat", input_schema: {} },
-					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", description: "Alias", input_schema: {} },
 					{ name: "totally_unknown", description: "Custom ext", input_schema: {} },
 				],
 				messages: [],
@@ -289,7 +294,7 @@ describe("pi-claude-code-use", () => {
 
 		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual([
 			"web_search_exa",
-			"mcp__exa__web_search",
+			"mcp__exa_mcp__web_search_exa",
 			"totally_unknown",
 		]);
 	});
@@ -298,20 +303,21 @@ describe("pi-claude-code-use", () => {
 	// tool_choice remapping
 	// ----------------------------------------------------------------
 
-	it("remaps tool_choice from flat companion name to MCP alias", () => {
+	it("remaps tool_choice from flat name to MCP alias", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				tool_choice: { type: "tool", name: "web_search_exa" },
 				tools: [
 					{ name: "web_search_exa", input_schema: {} },
-					{ name: "mcp__exa__web_search", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", input_schema: {} },
 				],
 				messages: [],
 			},
 			false,
 		);
 
-		expect(result.tool_choice).toEqual({ type: "tool", name: "mcp__exa__web_search" });
+		expect(result.tool_choice).toEqual({ type: "tool", name: "mcp__exa_mcp__web_search_exa" });
 	});
 
 	it("clears tool_choice when the referenced tool is filtered out", () => {
@@ -351,6 +357,7 @@ describe("pi-claude-code-use", () => {
 	// ----------------------------------------------------------------
 
 	it("renames tool_use blocks in message history when MCP alias survives filtering", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				messages: [
@@ -368,7 +375,7 @@ describe("pi-claude-code-use", () => {
 				],
 				tools: [
 					{ name: "web_search_exa", input_schema: {} },
-					{ name: "mcp__exa__web_search", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", input_schema: {} },
 				],
 			},
 			false,
@@ -379,7 +386,7 @@ describe("pi-claude-code-use", () => {
 				role: "assistant",
 				content: [
 					{ type: "text", text: "Searching..." },
-					{ type: "tool_use", id: "toolu_abc", name: "mcp__exa__web_search", input: { q: "test" } },
+					{ type: "tool_use", id: "toolu_abc", name: "mcp__exa_mcp__web_search_exa", input: { q: "test" } },
 				],
 			},
 			{
@@ -390,6 +397,7 @@ describe("pi-claude-code-use", () => {
 	});
 
 	it("preserves tool_use names when no MCP alias survives filtering", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				messages: [
@@ -416,6 +424,7 @@ describe("pi-claude-code-use", () => {
 	// ----------------------------------------------------------------
 
 	it("applies all transforms together: system rewrite, tool filter, tool_choice, messages", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				model: "claude-opus-4-6",
@@ -436,7 +445,7 @@ describe("pi-claude-code-use", () => {
 					{ name: "Read", description: "Read files", input_schema: {} },
 					{ type: "web_search", name: "web_search", search_context_size: "high" },
 					{ name: "web_search_exa", description: "Exa", input_schema: {} },
-					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", description: "Alias", input_schema: {} },
 					{ name: "mcp__custom__tool", description: "Custom", input_schema: {} },
 					{ name: "unknown_flat", description: "Dropped", input_schema: {} },
 				],
@@ -460,7 +469,7 @@ describe("pi-claude-code-use", () => {
 		expect((result.tools as { name?: string; type?: string }[]).map((t) => t.name ?? t.type)).toEqual([
 			"Read",
 			"web_search",
-			"mcp__exa__web_search",
+			"mcp__exa_mcp__web_search_exa",
 			"mcp__custom__tool",
 		]);
 
@@ -469,6 +478,7 @@ describe("pi-claude-code-use", () => {
 	});
 
 	it("passes tools, tool_choice, and messages through unchanged with filter disabled", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(
 			{
 				messages: [
@@ -480,7 +490,7 @@ describe("pi-claude-code-use", () => {
 				tool_choice: { type: "tool", name: "web_search_exa" },
 				tools: [
 					{ name: "web_search_exa", description: "Flat", input_schema: {} },
-					{ name: "mcp__exa__web_search", description: "Alias", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", description: "Alias", input_schema: {} },
 					{ name: "custom_ext_tool", description: "Custom", input_schema: {} },
 				],
 			},
@@ -489,7 +499,7 @@ describe("pi-claude-code-use", () => {
 
 		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual([
 			"web_search_exa",
-			"mcp__exa__web_search",
+			"mcp__exa_mcp__web_search_exa",
 			"custom_ext_tool",
 		]);
 		expect(result.tool_choice).toEqual({ type: "tool", name: "web_search_exa" });
@@ -502,151 +512,294 @@ describe("pi-claude-code-use", () => {
 	});
 
 	// ----------------------------------------------------------------
-	// Companion source matching
+	// Alias derivation
 	// ----------------------------------------------------------------
 
-	it("matches companion source by directory name from package root", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						baseDir: "/tmp/node_modules/@benvargas/pi-exa-mcp",
-						path: "/tmp/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
-					},
-				} as never,
-				spec,
-			),
-		).toBe(true);
+	describe("alias derivation", () => {
+		it("derives server segment from a scoped npm package path", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "/home/u/.pi/agent/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+					source: "t",
+					scope: "user",
+					origin: "package",
+				} as never),
+			).toBe("exa_mcp");
+		});
+
+		it("derives server segment from an unscoped npm package path", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "/x/node_modules/pi-web-providers/dist/index.js",
+					source: "t",
+					scope: "user",
+					origin: "package",
+				} as never),
+			).toBe("web_providers");
+		});
+
+		it("derives server segment from a monorepo package directory", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "/home/u/.pi/agent/git/github.com/ben-vargas/pi-packages/packages/pi-firecrawl/extensions/index.ts",
+					source: "t",
+					scope: "user",
+					origin: "package",
+				} as never),
+			).toBe("firecrawl");
+		});
+
+		it("derives server segment from a single-file extension stem", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "/home/u/.pi/agent/extensions/my-tool.ts",
+					source: "t",
+					scope: "user",
+					origin: "file",
+				} as never),
+			).toBe("my_tool");
+		});
+
+		it("uses 'pi' for synthetic builtin/sdk sources", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "<builtin:ls>",
+					source: "builtin",
+					scope: "user",
+					origin: "builtin",
+				} as never),
+			).toBe("pi");
+			expect(_test.deriveServerSegment(undefined)).toBe("pi");
+		});
+
+		it("handles Windows-style backslash paths", () => {
+			expect(
+				_test.deriveServerSegment({
+					path: "C:\\Users\\dev\\node_modules\\@benvargas\\pi-exa-mcp\\extensions\\index.ts",
+					source: "t",
+					scope: "user",
+					origin: "package",
+				} as never),
+			).toBe("exa_mcp");
+		});
+
+		it("builds full alias names from server segment and sanitized tool name", () => {
+			const tool = mockTool("web_search_exa", {
+				path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+			});
+			expect(_test.deriveAliasBase(tool as never)).toBe("mcp__exa_mcp__web_search_exa");
+		});
+
+		it("sanitizes hostile segments and falls back when empty", () => {
+			expect(_test.sanitizeAliasSegment("Weird Name!!", "ext")).toBe("weird_name");
+			expect(_test.sanitizeAliasSegment("---", "ext")).toBe("ext");
+		});
+
+		it("resolves collisions with deterministic numeric suffixes", () => {
+			const taken = new Set(["mcp__ext__tool"]);
+			expect(_test.reserveAliasName("mcp__ext__tool", taken)).toBe("mcp__ext__tool_2");
+			taken.add("mcp__ext__tool_2");
+			expect(_test.reserveAliasName("mcp__ext__tool", taken)).toBe("mcp__ext__tool_3");
+		});
+
+		it("keeps alias names within the 128-char limit even with suffixes", () => {
+			const base = `mcp__server__${"x".repeat(140)}`;
+			const taken = new Set<string>();
+			const first = _test.reserveAliasName(base, taken);
+			expect(first.length).toBe(128);
+			taken.add(first.toLowerCase());
+			const second = _test.reserveAliasName(base, taken);
+			expect(second.length).toBeLessThanOrEqual(128);
+			expect(second.endsWith("_2")).toBe(true);
+		});
 	});
 
-	it("matches companion source from extensions/ subdirectory layout", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						baseDir: "/worktree/packages/pi-exa-mcp/extensions",
-						path: "/worktree/packages/pi-exa-mcp/extensions/index.ts",
-					},
-				} as never,
-				spec,
-			),
-		).toBe(true);
-	});
+	// ----------------------------------------------------------------
+	// Dynamic alias registration (getAllTools-based)
+	// ----------------------------------------------------------------
 
-	it("rejects tools from unrelated extension directories", () => {
-		const spec = {
-			dirName: "pi-antigravity-image-gen",
-			packageName: "@benvargas/pi-antigravity-image-gen",
-			aliases: [] as const,
-		};
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "generate_image",
-					sourceInfo: {
-						baseDir: "/tmp/some-other-extension",
-						path: "/tmp/some-other-extension/extensions/index.ts",
-					},
-				} as never,
-				spec,
-			),
-		).toBe(false);
-	});
+	describe("registerMcpAliases", () => {
+		let tempDir: string;
 
-	it("matches companion source via path when baseDir is absent", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						path: "/worktree/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
-						source: "test",
-						scope: "user" as const,
-						origin: "package" as const,
-					},
-				} as never,
-				spec,
-			),
-		).toBe(true);
-	});
+		beforeEach(() => {
+			tempDir = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+		});
 
-	it("rejects tools from packages whose names are prefixes of the companion package", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						path: "/worktree/node_modules/@benvargas/pi-exa-mcp-wrapper/extensions/index.ts",
-						source: "test",
-						scope: "user" as const,
-						origin: "package" as const,
-					},
-				} as never,
-				spec,
-			),
-		).toBe(false);
-	});
+		afterEach(() => {
+			rmSync(tempDir, { recursive: true, force: true });
+		});
 
-	it("matches companion source via dirName fallback for monorepo/git installs", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						// baseDir is the monorepo root, not the individual package
-						baseDir: "/home/user/.pi/agent/git/github.com/ben-vargas/pi-packages",
-						path: "/home/user/.pi/agent/git/github.com/ben-vargas/pi-packages/packages/pi-exa-mcp/extensions/index.ts",
-						source: "test",
-						scope: "user" as const,
-						origin: "package" as const,
-					},
-				} as never,
-				spec,
-			),
-		).toBe(true);
-	});
+		it("registers derived MCP aliases for non-core flat tools", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("read"),
+				mockTool("web_search_exa", {
+					path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts",
+					description: "Search the web with Exa",
+				}),
+			]);
 
-	it("matches companion source via Windows-style backslash paths", () => {
-		const spec = { dirName: "pi-exa-mcp", packageName: "@benvargas/pi-exa-mcp", aliases: [] as const };
-		expect(
-			_test.isCompanionSource(
-				{
-					name: "web_search_exa",
-					sourceInfo: {
-						path: "C:\\Users\\dev\\node_modules\\@benvargas\\pi-exa-mcp\\extensions\\index.ts",
-						source: "test",
-						scope: "user" as const,
-						origin: "package" as const,
-					},
-				} as never,
-				spec,
-			),
-		).toBe(true);
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+			expect(pi.registerTool).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: "mcp__exa_mcp__web_search_exa",
+					label: "MCP web_search_exa",
+					description: "Search the web with Exa",
+				}),
+			);
+			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa_mcp__web_search_exa");
+			expect(_test.MCP_TO_FLAT.get("mcp__exa_mcp__web_search_exa")).toBe("web_search_exa");
+			expect(_test.registeredMcpAliases.has("mcp__exa_mcp__web_search_exa")).toBe(true);
+		});
+
+		it("does not alias core tools or mcp__-prefixed tools", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([mockTool("read"), mockTool("Bash"), mockTool("mcp__real__server_tool")]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(pi.registerTool).not.toHaveBeenCalled();
+			expect(_test.FLAT_TO_MCP.size).toBe(0);
+		});
+
+		it("picks up tools registered by other extensions' lifecycle hooks on a later pass", () => {
+			const pi = createMockPi();
+			// First pass: companion extension has not registered its tools yet.
+			pi.getAllTools.mockReturnValue([mockTool("read")]);
+			registerAliasesIsolated(pi, tempDir);
+			expect(pi.registerTool).not.toHaveBeenCalled();
+
+			// Second pass (before_agent_start): hook-registered tool now present.
+			pi.getAllTools.mockReturnValue([
+				mockTool("read"),
+				mockTool("web_search", { path: "/x/node_modules/pi-web-providers/dist/index.js" }),
+			]);
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__web_providers__web_search" }));
+			expect(_test.FLAT_TO_MCP.get("web_search")).toBe("mcp__web_providers__web_search");
+		});
+
+		it("registers alias stubs whose execute throws instead of shadow-executing", async () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+			]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			const def = pi.registerTool.mock.calls[0]?.[0] as {
+				execute: (...args: unknown[]) => Promise<unknown>;
+			};
+			await expect(def.execute()).rejects.toThrow(/routed it to "web_search_exa"/);
+		});
+
+		it("assigns deterministic suffixes when two tools derive the same alias", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				// Distinct flat names that sanitize to the same alias segment:
+				mockTool("my-search", { path: "/x/node_modules/pi-ext-a/index.js" }),
+				mockTool("my_search", { path: "/y/node_modules/pi-ext-a/index.js" }),
+			]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			const names = pi.registerTool.mock.calls.map((c) => (c[0] as { name: string }).name).sort();
+			expect(names).toEqual(["mcp__ext_a__my_search", "mcp__ext_a__my_search_2"]);
+			// Sorted by lowercased flat name: "my-search" < "my_search" — order is deterministic.
+			expect(_test.FLAT_TO_MCP.get("my-search")).toBe("mcp__ext_a__my_search");
+			expect(_test.FLAT_TO_MCP.get("my_search")).toBe("mcp__ext_a__my_search_2");
+		});
+
+		it("does not derive an alias name that collides with an existing tool", () => {
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("mcp__ext_a__search"),
+				mockTool("search", { path: "/x/node_modules/pi-ext-a/index.js" }),
+			]);
+
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__ext_a__search_2" }));
+		});
+
+		it("keeps alias assignments stable across repeated passes", () => {
+			const pi = createMockPi();
+			const tools = [mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" })];
+			pi.getAllTools.mockReturnValue(tools);
+
+			registerAliasesIsolated(pi, tempDir);
+			const firstAlias = _test.FLAT_TO_MCP.get("web_search_exa");
+
+			// Second pass: the alias tool is now part of the registry.
+			pi.getAllTools.mockReturnValue([...tools, mockTool(firstAlias as string)]);
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe(firstAlias);
+			// Registered exactly once.
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+		});
+
+		it("skips auto-derivation when PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS=1", () => {
+			vi.stubEnv("PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS", "1");
+			try {
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+				]);
+
+				registerAliasesIsolated(pi, tempDir);
+
+				expect(pi.registerTool).not.toHaveBeenCalled();
+				expect(_test.FLAT_TO_MCP.size).toBe(0);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("still applies user-configured aliases when auto-derivation is disabled", () => {
+			vi.stubEnv("PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS", "1");
+			try {
+				const projectDir = join(tempDir, "project");
+				const configPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
+				mkdirSync(dirname(configPath), { recursive: true });
+				writeFileSync(configPath, JSON.stringify({ toolAliases: [["web_search_exa", "mcp__exa__web_search"]] }));
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+				]);
+
+				registerAliasesIsolated(pi, tempDir);
+
+				expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__exa__web_search" }));
+				expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa__web_search");
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
 	});
 
 	// ----------------------------------------------------------------
 	// Alias activation tracking
 	// ----------------------------------------------------------------
 
-	it("activates MCP aliases for active companion tools, then removes them on disable", () => {
+	it("activates MCP aliases for active flat source tools, then removes them on disable", () => {
 		const pi = createMockPi();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
-		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
 		pi.getActiveTools.mockReturnValue(["read", "web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
-		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa", "mcp__exa__web_search"]);
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
 
 		// Now disable: should remove the alias
 		pi.setActiveTools.mockClear();
-		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa__web_search"]);
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "web_search_exa"]);
@@ -679,13 +832,14 @@ describe("pi-claude-code-use", () => {
 
 	it("prunes auto-activated aliases when their flat counterpart is no longer active", () => {
 		const pi = createMockPi();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
-		_test.autoActivatedAliases.add("mcp__exa__web_search");
-		_test.setLastManagedToolList(["read", "mcp__exa__web_search"]);
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.autoActivatedAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.setLastManagedToolList(["read", "mcp__exa_mcp__web_search_exa"]);
 
-		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
 		// web_search_exa is NOT active, only the alias is (stale state)
-		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
@@ -693,12 +847,13 @@ describe("pi-claude-code-use", () => {
 
 	it("preserves aliases the user explicitly enabled via the tool picker", () => {
 		const pi = createMockPi();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
 		// Alias is NOT in autoActivatedAliases → user added it manually
 
-		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
 		// web_search_exa is not active, but user manually enabled the MCP alias
-		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		// User-selected alias is preserved even without flat counterpart active
@@ -707,14 +862,15 @@ describe("pi-claude-code-use", () => {
 
 	it("promotes auto-activated alias to user-selected when user removes flat but keeps alias", () => {
 		const pi = createMockPi();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
-		_test.autoActivatedAliases.add("mcp__exa__web_search");
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.autoActivatedAliases.add("mcp__exa_mcp__web_search_exa");
 		// Last sync had both flat + alias active
-		_test.setLastManagedToolList(["read", "web_search_exa", "mcp__exa__web_search"]);
+		_test.setLastManagedToolList(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
 
-		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
 		// User removed web_search_exa (was in last managed) but kept the MCP alias
-		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		// Alias promoted to user-selected → preserved even though flat is inactive
@@ -723,13 +879,14 @@ describe("pi-claude-code-use", () => {
 
 	it("prunes auto-activated aliases when flat was never managed (no promotion)", () => {
 		const pi = createMockPi();
-		_test.registeredMcpAliases.add("mcp__exa__web_search");
-		_test.autoActivatedAliases.add("mcp__exa__web_search");
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.autoActivatedAliases.add("mcp__exa_mcp__web_search_exa");
 		// Last sync did NOT include web_search_exa → flat was never managed
-		_test.setLastManagedToolList(["read", "mcp__exa__web_search"]);
+		_test.setLastManagedToolList(["read", "mcp__exa_mcp__web_search_exa"]);
 
-		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
-		pi.getActiveTools.mockReturnValue(["read", "mcp__exa__web_search"]);
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		// Flat was never in managed list → no promotion, alias is pruned
@@ -738,6 +895,7 @@ describe("pi-claude-code-use", () => {
 
 	it("does not auto-manage MCP aliases that were not registered by this extension", () => {
 		const pi = createMockPi();
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa__web_search"]]);
 		// mcp__exa__web_search exists in allTools and activeTools, but is NOT in registeredMcpAliases
 		// (simulates a third-party extension providing this MCP tool directly)
 		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa__web_search")]);
@@ -760,7 +918,7 @@ describe("pi-claude-code-use", () => {
 		// refreshAliasMap stores the mcp value RAW (mixed-case), simulating a user
 		// who put ["my_tool", "MCP__Foo__Bar"] in their pi-claude-code-use.json.
 		_test.refreshAliasMap([["my_tool", "MCP__Foo__Bar"]]);
-		// registerMcpAlias normalizes via lower(mcpName) before adding; mirror that here.
+		// registerMcpAliases normalizes via lower(mcpName) before adding; mirror that here.
 		_test.registeredMcpAliases.add("mcp__foo__bar");
 		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
 		pi.getActiveTools.mockReturnValue(["read", "my_tool"]);
@@ -782,7 +940,7 @@ describe("pi-claude-code-use", () => {
 	it("preserves user-selected mixed-case mcp aliases on sync", () => {
 		const pi = createMockPi();
 		_test.refreshAliasMap([["my_tool", "MCP__Foo__Bar"]]);
-		// registerMcpAlias normalizes via lower(mcpName) before adding; mirror that here.
+		// registerMcpAliases normalizes via lower(mcpName) before adding; mirror that here.
 		_test.registeredMcpAliases.add("mcp__foo__bar");
 		pi.getAllTools.mockReturnValue([mockTool("my_tool"), mockTool("MCP__Foo__Bar")]);
 		// User manually selected the mixed-case alias via the tool picker.
@@ -794,37 +952,7 @@ describe("pi-claude-code-use", () => {
 
 		// With lower(), the alias is recognized as registered → preserved
 		// → next === activeNames → setActiveTools is NOT called.
-		// Without lower(), the alias is dropped from activeRegistered → next = ["read"]
-		// → setActiveTools(["read"]) is called, silently breaking the user's selection.
 		expect(pi.setActiveTools).not.toHaveBeenCalled();
-	});
-
-	// ----------------------------------------------------------------
-	// Capture shim
-	// ----------------------------------------------------------------
-
-	it("suppresses duplicate registration while gating flags through the capture shim", () => {
-		const pi = {
-			...createMockPi(),
-			getFlag: vi.fn((_name: string) => "test-value"),
-		};
-
-		const captured = new Map();
-		const shim = _test.buildCaptureShim(pi as unknown as ExtensionAPI, captured);
-
-		// Before registration, shim returns undefined (flag not tracked)
-		expect(shim.getFlag("exa-mcp-tools")).toBeUndefined();
-
-		// After registration, shim tracks in shimFlags and delegates getFlag to realPi
-		shim.registerFlag("exa-mcp-tools", { description: "tools", type: "string" });
-		expect(pi.registerFlag).not.toHaveBeenCalled();
-		expect(shim.getFlag("exa-mcp-tools")).toBe("test-value");
-
-		// Unregistered flags still return undefined through shim
-		expect(shim.getFlag("other-flag")).toBeUndefined();
-
-		shim.registerEntryRenderer("captured-entry", () => undefined);
-		expect(pi.registerEntryRenderer).not.toHaveBeenCalled();
 	});
 
 	// ----------------------------------------------------------------
@@ -904,75 +1032,6 @@ describe("pi-claude-code-use", () => {
 	});
 
 	// ----------------------------------------------------------------
-	// Companion loading integration
-	// ----------------------------------------------------------------
-
-	it("registers MCP alias tools from companion extension factories", async () => {
-		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
-		const tempRoot = join(tempParent, "pi-exa-mcp");
-		const isolatedAgentDir = join(tempParent, "agent");
-		try {
-			const extDir = join(tempRoot, "extensions");
-			mkdirSync(extDir, { recursive: true });
-			writeFileSync(
-				join(extDir, "index.js"),
-				[
-					'import { StringEnum } from "@mariozechner/pi-ai";',
-					'import { DEFAULT_MAX_BYTES } from "@earendil-works/pi-coding-agent";',
-					'import { Type } from "typebox";',
-					"const schema = Type.Object({ q: StringEnum(['web']) });",
-					"export default function companion(pi) {",
-					"  pi.registerEntryRenderer('test-entry', () => undefined);",
-					"  pi.registerTool({",
-					'    name: "web_search_exa",',
-					"    description: 'Search web ' + String(DEFAULT_MAX_BYTES),",
-					"    inputSchema: schema,",
-					"    async execute() { return { content: [{ type: 'text', text: String(DEFAULT_MAX_BYTES) }] }; }",
-					"  });",
-					"}",
-				].join("\n"),
-				"utf-8",
-			);
-
-			const pi = createMockPi();
-			pi.getAllTools.mockReturnValue([
-				mockTool("web_search_exa", { baseDir: tempRoot, path: join(extDir, "index.js") }),
-			]);
-
-			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
-				cwd: tempParent,
-				agentDir: isolatedAgentDir,
-			});
-
-			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__exa__web_search" }));
-			expect(pi.registerEntryRenderer).not.toHaveBeenCalled();
-		} finally {
-			rmSync(tempParent, { recursive: true, force: true });
-		}
-	});
-
-	it("refuses to alias tools from unrelated packages even if names match", async () => {
-		const tempParent = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
-		try {
-			const pi = createMockPi();
-			pi.getAllTools.mockReturnValue([
-				mockTool("generate_image", {
-					baseDir: "/tmp/node_modules/some-random-ext",
-					path: "/tmp/node_modules/some-random-ext/extensions/index.ts",
-				}),
-			]);
-
-			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
-				cwd: tempParent,
-				agentDir: join(tempParent, "agent"),
-			});
-			expect(pi.registerTool).not.toHaveBeenCalled();
-		} finally {
-			rmSync(tempParent, { recursive: true, force: true });
-		}
-	});
-
-	// ----------------------------------------------------------------
 	// User-defined tool aliases (pi-claude-code-use.json)
 	// ----------------------------------------------------------------
 
@@ -1044,84 +1103,111 @@ describe("pi-claude-code-use", () => {
 			expect(load()).toEqual([]);
 		});
 
-		it("removes stale user aliases when project config changes", async () => {
+		it("user overrides win over derived aliases", () => {
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["web_search_exa", "mcp__exa__web_search"]] }));
+
 			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([
+				mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+			]);
 
-			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
-			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
-				cwd: projectDir,
-				agentDir,
-			});
+			_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
 
-			const withAlias = _test.transformPayload(
-				{
-					tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
-					tool_choice: { type: "tool", name: "subagent" },
-					messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
-				},
-				false,
-			);
-			expect(withAlias.tool_choice).toEqual({ type: "tool", name: "mcp__subagent__run" });
-			expect((withAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
-				"mcp__subagent__run",
-			);
-
-			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
-			await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
-				cwd: projectDir,
-				agentDir,
-			});
-
-			const withoutAlias = _test.transformPayload(
-				{
-					tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
-					tool_choice: { type: "tool", name: "subagent" },
-					messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
-				},
-				false,
-			);
-			expect(withoutAlias.tool_choice).toBeUndefined();
-			expect((withoutAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
-				"subagent",
-			);
-
-			_test.registeredMcpAliases.add("mcp__subagent__run");
-			pi.getActiveTools.mockReturnValue(["subagent"]);
-			pi.getAllTools.mockReturnValue([mockTool("subagent"), mockTool("mcp__subagent__run")]);
-			_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
-			expect(pi.setActiveTools).not.toHaveBeenCalled();
+			expect(pi.registerTool).toHaveBeenCalledTimes(1);
+			expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__exa__web_search" }));
+			expect(_test.FLAT_TO_MCP.get("web_search_exa")).toBe("mcp__exa__web_search");
 		});
 
-		it("registers an MCP alias for a user-configured flat tool using its sourceInfo path", async () => {
+		it("ignores user aliases that are not mcp__-prefixed", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "not_an_mcp_name"]] }));
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([mockTool("subagent")]);
+
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				expect(pi.registerTool).not.toHaveBeenCalledWith(expect.objectContaining({ name: "not_an_mcp_name" }));
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining('alias must start with "mcp__"'));
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
+		it("keeps user alias mappings for flat tools that are not in the registry", () => {
 			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
 
-			const extDir = join(projectDir, "my-subagent-ext");
-			mkdirSync(extDir, { recursive: true });
-			writeFileSync(
-				join(extDir, "index.js"),
-				[
-					'import { Type } from "typebox";',
-					"const schema = Type.Object({ task: Type.String() });",
-					"export default function subagentExt(pi) {",
-					"  pi.registerTool({",
-					'    name: "subagent",',
-					"    description: 'User-configured subagent tool',",
-					"    inputSchema: schema,",
-					"    async execute() { return { content: [{ type: 'text', text: 'ok' }] }; }",
-					"  });",
-					"}",
-				].join("\n"),
-			);
+			const pi = createMockPi();
+			pi.getAllTools.mockReturnValue([]);
+
+			_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+			// Nothing to register (no schema available) but the payload mapping applies.
+			expect(pi.registerTool).not.toHaveBeenCalled();
+			expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__subagent__run");
+		});
+
+		it("removes stale user aliases when project config changes", () => {
+			vi.stubEnv("PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS", "1");
+			try {
+				const pi = createMockPi();
+
+				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				const withAlias = _test.transformPayload(
+					{
+						tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
+						tool_choice: { type: "tool", name: "subagent" },
+						messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
+					},
+					false,
+				);
+				expect(withAlias.tool_choice).toEqual({ type: "tool", name: "mcp__subagent__run" });
+				expect((withAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
+					"mcp__subagent__run",
+				);
+
+				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [] }));
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				const withoutAlias = _test.transformPayload(
+					{
+						tools: [{ name: "subagent" }, { name: "mcp__subagent__run" }],
+						tool_choice: { type: "tool", name: "subagent" },
+						messages: [{ role: "assistant", content: [{ type: "tool_use", name: "subagent" }] }],
+					},
+					false,
+				);
+				expect(withoutAlias.tool_choice).toBeUndefined();
+				expect((withoutAlias.messages as Array<{ content: Array<{ name: string }> }>)[0]?.content[0]?.name).toBe(
+					"subagent",
+				);
+
+				_test.registeredMcpAliases.add("mcp__subagent__run");
+				pi.getActiveTools.mockReturnValue(["subagent"]);
+				pi.getAllTools.mockReturnValue([mockTool("subagent"), mockTool("mcp__subagent__run")]);
+				_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+				expect(pi.setActiveTools).not.toHaveBeenCalled();
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it("registers a schema-backed alias for a user-configured flat tool", () => {
+			writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["subagent", "mcp__subagent__run"]] }));
 
 			const pi = createMockPi();
-			pi.getAllTools.mockReturnValue([mockTool("subagent", { baseDir: extDir, path: join(extDir, "index.js") })]);
+			pi.getAllTools.mockReturnValue([
+				mockTool("subagent", { path: "/x/my-subagent-ext/index.js", description: "User-configured subagent tool" }),
+			]);
 
 			try {
-				await _test.registerMcpAliases(pi as unknown as ExtensionAPI, {
-					cwd: projectDir,
-					agentDir,
-				});
-				expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "mcp__subagent__run" }));
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+				expect(pi.registerTool).toHaveBeenCalledWith(
+					expect.objectContaining({ name: "mcp__subagent__run", description: "User-configured subagent tool" }),
+				);
 				expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__subagent__run");
 			} finally {
 				_test.FLAT_TO_MCP.delete("subagent");
@@ -1225,10 +1311,31 @@ describe("pi-claude-code-use", () => {
 			expect(result.message.content[0].name).toBe("run_chain");
 		});
 
-		it("leaves foreign mcp__ toolCalls untouched when registeredMcpAliases is empty", () => {
-			// refreshAliasMap re-seeds builtins (including mcp__exa__web_search → web_search_exa)
-			// but registeredMcpAliases is cleared by the top-level beforeEach and not populated here.
-			_test.refreshAliasMap([]);
+		it("rewrites derived alias toolCalls back to the flat source name", () => {
+			const pi = createMockPi();
+			const tempDir = mkdtempSync(join(tmpdir(), "pi-claude-code-use-"));
+			try {
+				pi.getAllTools.mockReturnValue([
+					mockTool("web_search_exa", { path: "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts" }),
+				]);
+				registerAliasesIsolated(pi, tempDir);
+
+				const msg = {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "y", name: "mcp__exa_mcp__web_search_exa", arguments: {} }],
+				};
+
+				const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
+				expect(out).toBeDefined();
+				expect((out?.content[0] as { name: string }).name).toBe("web_search_exa");
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("leaves foreign mcp__ toolCalls untouched when not registered by this extension", () => {
+			_test.refreshAliasMap([["web_search_exa", "mcp__exa__web_search"]]);
+			// Mapping exists but the alias was NOT registered by this extension.
 
 			const msg = {
 				role: "assistant",
@@ -1238,23 +1345,12 @@ describe("pi-claude-code-use", () => {
 			expect(_test.unaliasToolCalls(msg)).toBeUndefined();
 		});
 
-		it("rewrites mcp__exa__web_search → web_search_exa when registered by this extension", () => {
-			_test.refreshAliasMap([]);
-			_test.registeredMcpAliases.add("mcp__exa__web_search");
-
-			const msg = {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "y", name: "mcp__exa__web_search", arguments: {} }],
-			};
-
-			const out = _test.unaliasToolCalls(msg) as typeof msg | undefined;
-			expect(out).toBeDefined();
-			expect((out?.content[0] as { name: string }).name).toBe("web_search_exa");
-		});
-
 		it("in a mixed message, only registered aliases are rewritten; foreign mcp__ names are preserved", () => {
-			_test.refreshAliasMap([["run_chain", "mcp__chain__run_chain"]]);
-			// Register only the user-defined alias; the builtin exa alias is NOT registered.
+			_test.refreshAliasMap([
+				["run_chain", "mcp__chain__run_chain"],
+				["web_search_exa", "mcp__exa__web_search"],
+			]);
+			// Register only the first alias; the exa alias is NOT registered.
 			_test.registeredMcpAliases.add("mcp__chain__run_chain");
 
 			const msg = {
@@ -1269,21 +1365,6 @@ describe("pi-claude-code-use", () => {
 			expect(out).toBeDefined();
 			expect((out?.content[0] as { name: string }).name).toBe("run_chain");
 			expect((out?.content[1] as { name: string }).name).toBe("mcp__exa__web_search");
-		});
-
-		it("leaves user-defined mcp__ toolCalls untouched when not registered by this extension", () => {
-			// Seed MCP_TO_FLAT with a user alias entry, but do NOT add it to
-			// registeredMcpAliases. Simulates a model emitting an alias name that
-			// another extension actually owns — this extension must not rewrite it.
-			_test.refreshAliasMap([["my_custom_tool", "mcp__custom__do_thing"]]);
-			_test.registeredMcpAliases.clear();
-
-			const msg = {
-				role: "assistant",
-				content: [{ type: "toolCall", id: "1", name: "mcp__custom__do_thing", arguments: {} }],
-			};
-
-			expect(_test.unaliasToolCalls(msg)).toBeUndefined();
 		});
 
 		it("rewrites mixed-case mcp__ toolCall names (case-insensitive lookup)", () => {

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -80,6 +80,7 @@ describe("pi-claude-code-use", () => {
 		_test.aliasAssignments.clear();
 		_test.registeredAliasRoutes.clear();
 		_test.aliasSourceMeta.clear();
+		_test.aliasExactNames.clear();
 		_test.setLastManagedToolList(undefined);
 		_test.refreshAliasMap([]);
 	});
@@ -268,6 +269,35 @@ describe("pi-claude-code-use", () => {
 				input_schema: { v: 2 },
 				cache_control: { type: "ephemeral", ttl: "1h" },
 			}),
+		]);
+	});
+
+	it("prefers the renamed flat entry over a stale alias stub regardless of payload order", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		const result = _test.transformPayload(
+			{
+				tools: [
+					// Alias stub FIRST in the payload, with a stale schema.
+					{
+						name: "mcp__exa_mcp__web_search_exa",
+						description: "Stale alias stub",
+						input_schema: { v: 1 },
+						cache_control: { type: "ephemeral", ttl: "1h" },
+					},
+					{ name: "web_search_exa", description: "Current", input_schema: { v: 2 } },
+				],
+				messages: [],
+			},
+			false,
+		);
+
+		expect(result.tools).toEqual([
+			{
+				name: "mcp__exa_mcp__web_search_exa",
+				description: "Current",
+				input_schema: { v: 2 },
+				cache_control: { type: "ephemeral", ttl: "1h" },
+			},
 		]);
 	});
 
@@ -772,6 +802,32 @@ describe("pi-claude-code-use", () => {
 			}
 		});
 
+		it("tracks a case-only alias rename as a new auto-activated exact name", () => {
+			const pi = createMockPi();
+			const path = "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts";
+			const projectDir = join(tempDir, "project");
+			const configPath = join(projectDir, ".pi", "extensions", "pi-claude-code-use.json");
+			mkdirSync(dirname(configPath), { recursive: true });
+
+			const tool = mockTool("web_search_exa", { path });
+			pi.getAllTools.mockReturnValue([tool]);
+
+			writeFileSync(configPath, JSON.stringify({ toolAliases: [["web_search_exa", "MCP__Exa__Search"]] }));
+			registerAliasesIsolated(pi, tempDir);
+			expect(_test.autoActivatedAliases.has("MCP__Exa__Search")).toBe(true);
+
+			// Simulate the user having promoted the old casing, then changing the
+			// config to a different casing. Pi keys tools by exact name, so the new
+			// casing is a brand-new (auto-activated) tool name.
+			_test.autoActivatedAliases.clear();
+			writeFileSync(configPath, JSON.stringify({ toolAliases: [["web_search_exa", "mcp__exa__search"]] }));
+			registerAliasesIsolated(pi, tempDir);
+
+			expect(pi.registerTool).toHaveBeenCalledTimes(2);
+			expect(pi.registerTool).toHaveBeenLastCalledWith(expect.objectContaining({ name: "mcp__exa__search" }));
+			expect(_test.autoActivatedAliases.has("mcp__exa__search")).toBe(true);
+		});
+
 		it("does not flip a user-selected alias back to auto-managed on schema re-registration", () => {
 			const pi = createMockPi();
 			const path = "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts";
@@ -951,6 +1007,38 @@ describe("pi-claude-code-use", () => {
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("promotes kept aliases for mixed-case flat tools (case-insensitive baseline comparison)", () => {
+		const pi = createMockPi();
+		_test.refreshAliasMap([], [["MyTool", "mcp__x__mytool"]]);
+		_test.registeredMcpAliases.add("mcp__x__mytool");
+		_test.autoActivatedAliases.add("mcp__x__mytool");
+		_test.setLastManagedToolList(["read", "MyTool", "mcp__x__mytool"]);
+
+		pi.getAllTools.mockReturnValue([mockTool("MyTool"), mockTool("mcp__x__mytool")]);
+		// User removed the exact-cased flat tool but kept the alias.
+		pi.getActiveTools.mockReturnValue(["read", "mcp__x__mytool"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+		expect(_test.autoActivatedAliases.has("mcp__x__mytool")).toBe(false);
+	});
+
+	it("honors a kept alias when switching to non-OAuth before another enabled sync", () => {
+		const pi = createMockPi();
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.autoActivatedAliases.add("mcp__exa_mcp__web_search_exa");
+		_test.setLastManagedToolList(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
+		// User removed the flat tool, kept the alias, then switched models: the
+		// next sync is the DISABLE branch, which must still honor the choice.
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
+
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, false);
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
 	});
 
 	it("records the managed baseline even when the first sync is a no-op, enabling later promotion", () => {
@@ -1332,6 +1420,28 @@ describe("pi-claude-code-use", () => {
 				// The foreign tool must not be routed to; derivation applies instead.
 				expect(_test.FLAT_TO_MCP.get("subagent")).toBe("mcp__sub__subagent");
 				expect(_test.MCP_TO_FLAT.has("mcp__real__tool")).toBe(false);
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
+		it("rejects overrides whose flat tool has a case-insensitive duplicate", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			try {
+				writeFileSync(projectConfigPath, JSON.stringify({ toolAliases: [["mytool", "mcp__x__mytool"]] }));
+
+				const pi = createMockPi();
+				pi.getAllTools.mockReturnValue([
+					mockTool("MyTool", { path: "/x/node_modules/pi-ext-a/index.js" }),
+					mockTool("mytool", { path: "/y/node_modules/pi-ext-b/index.js" }),
+				]);
+
+				_test.registerMcpAliases(pi as unknown as ExtensionAPI, { cwd: projectDir, agentDir });
+
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("case-insensitive duplicate in the registry"));
+				expect(pi.registerTool).not.toHaveBeenCalled();
+				expect(_test.FLAT_TO_MCP.size).toBe(0);
+				expect(_test.MCP_TO_FLAT.size).toBe(0);
 			} finally {
 				warn.mockRestore();
 			}

--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -245,11 +245,11 @@ describe("pi-claude-code-use", () => {
 		const result = _test.transformPayload(
 			{
 				tools: [
-					{ name: "web_search_exa", description: "Flat", input_schema: {} },
+					{ name: "web_search_exa", description: "Current", input_schema: { v: 2 } },
 					{
 						name: "mcp__exa_mcp__web_search_exa",
-						description: "Alias",
-						input_schema: {},
+						description: "Stale alias stub",
+						input_schema: { v: 1 },
 						cache_control: { type: "ephemeral", ttl: "1h" },
 					},
 				],
@@ -259,9 +259,13 @@ describe("pi-claude-code-use", () => {
 		);
 
 		expect((result.tools as { name: string }[]).map((t) => t.name)).toEqual(["mcp__exa_mcp__web_search_exa"]);
+		// The flat entry always carries the source tool's CURRENT schema, so the
+		// renamed flat entry wins over a potentially stale alias stub — while the
+		// advertised alias entry's cache_control is preserved.
 		expect(result.tools).toEqual([
 			expect.objectContaining({
-				description: "Alias",
+				description: "Current",
+				input_schema: { v: 2 },
 				cache_control: { type: "ephemeral", ttl: "1h" },
 			}),
 		]);
@@ -746,7 +750,7 @@ describe("pi-claude-code-use", () => {
 			expect(def.promptGuidelines).toBe(promptGuidelines);
 		});
 
-		it("skips case-insensitive duplicate flat tool names deterministically", () => {
+		it("excludes case-insensitive duplicate flat tool names from aliasing entirely", () => {
 			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 			try {
 				const pi = createMockPi();
@@ -757,11 +761,33 @@ describe("pi-claude-code-use", () => {
 
 				registerAliasesIsolated(pi, tempDir);
 
-				expect(pi.registerTool).toHaveBeenCalledTimes(1);
+				// Aliasing either variant could route a call for one tool to the other
+				// (all alias state is lowercase-keyed, pi execution lookup is exact),
+				// so neither gets an alias.
+				expect(pi.registerTool).not.toHaveBeenCalled();
+				expect(_test.FLAT_TO_MCP.size).toBe(0);
 				expect(warn).toHaveBeenCalledWith(expect.stringContaining("case-insensitive duplicate"));
 			} finally {
 				warn.mockRestore();
 			}
+		});
+
+		it("does not flip a user-selected alias back to auto-managed on schema re-registration", () => {
+			const pi = createMockPi();
+			const path = "/x/node_modules/@benvargas/pi-exa-mcp/extensions/index.ts";
+			pi.getAllTools.mockReturnValue([mockTool("web_search_exa", { path, description: "v1" })]);
+			registerAliasesIsolated(pi, tempDir);
+			expect(_test.autoActivatedAliases.has("mcp__exa_mcp__web_search_exa")).toBe(true);
+
+			// Simulate promotion to user-selected (user kept the alias deliberately).
+			_test.autoActivatedAliases.delete("mcp__exa_mcp__web_search_exa");
+
+			// Source schema changes → alias re-registered, but provenance must not flip:
+			// pi preserves activation for same-name re-registrations.
+			pi.getAllTools.mockReturnValue([mockTool("web_search_exa", { path, description: "v2" })]);
+			registerAliasesIsolated(pi, tempDir);
+			expect(pi.registerTool).toHaveBeenCalledTimes(2);
+			expect(_test.autoActivatedAliases.has("mcp__exa_mcp__web_search_exa")).toBe(false);
 		});
 
 		it("registers alias stubs whose execute throws instead of shadow-executing", async () => {
@@ -925,6 +951,30 @@ describe("pi-claude-code-use", () => {
 
 		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("records the managed baseline even when the first sync is a no-op, enabling later promotion", () => {
+		const pi = createMockPi();
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		_test.registeredMcpAliases.add("mcp__exa_mcp__web_search_exa");
+		// Pi already auto-activated the fresh alias, and registration marked it auto-managed.
+		_test.autoActivatedAliases.add("mcp__exa_mcp__web_search_exa");
+
+		pi.getAllTools.mockReturnValue([mockTool("web_search_exa"), mockTool("mcp__exa_mcp__web_search_exa")]);
+		pi.getActiveTools.mockReturnValue(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
+
+		// First sync: everything already in the desired state → no setActiveTools
+		// call, but the baseline must still be recorded.
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+		expect(_test.getLastManagedToolList()).toEqual(["read", "web_search_exa", "mcp__exa_mcp__web_search_exa"]);
+
+		// User removes the flat tool via the picker but keeps the alias: promotion
+		// must recognize the deliberate choice and preserve the alias.
+		pi.getActiveTools.mockReturnValue(["read", "mcp__exa_mcp__web_search_exa"]);
+		_test.syncAliasActivation(pi as unknown as ExtensionAPI, true);
+		expect(pi.setActiveTools).not.toHaveBeenCalled();
+		expect(_test.autoActivatedAliases.has("mcp__exa_mcp__web_search_exa")).toBe(false);
 	});
 
 	it("preserves aliases the user explicitly enabled via the tool picker", () => {

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -274,10 +274,17 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 		if (mcpAlias) {
 			const aliasLc = lower(mcpAlias);
 			if ((advertised.has(aliasLc) || registeredMcpAliases.has(aliasLc)) && !emitted.has(aliasLc)) {
-				// Prefer the advertised alias entry to preserve its metadata,
-				// including cache_control; otherwise rename the flat entry.
+				// Rename the FLAT entry: it always carries the source tool's current
+				// schema, whereas an advertised alias stub can lag one turn behind a
+				// mid-session source schema update. Preserve the advertised alias
+				// entry's cache_control so prompt-cache breakpoints survive.
 				emitted.add(aliasLc);
-				result.push(toolsByName.get(aliasLc) ?? { ...tool, name: mcpAlias });
+				const advertisedAlias = toolsByName.get(aliasLc);
+				const renamed: Record<string, unknown> = { ...tool, name: mcpAlias };
+				if (advertisedAlias?.cache_control !== undefined && renamed.cache_control === undefined) {
+					renamed.cache_control = advertisedAlias.cache_control;
+				}
+				result.push(renamed);
 			} else if (disableFilter && !emitted.has(nameLc)) {
 				// Filter disabled: keep flat name if not yet emitted
 				emitted.add(nameLc);
@@ -603,6 +610,7 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 			// Never shadow an existing tool (e.g. a real MCP tool from another extension).
 			return;
 		}
+		const isNewRegistration = !registeredMcpAliases.has(mcpLc);
 		pi.registerTool({
 			name: mcpName,
 			label: `MCP ${tool.name}`,
@@ -621,11 +629,15 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		registeredMcpAliases.add(mcpLc);
 		registeredAliasRoutes.set(mcpLc, tool.name);
 		aliasSourceMeta.set(mcpLc, meta);
-		// Pi auto-activates newly registered tools. Track the alias as
-		// auto-managed so syncAliasActivation can deactivate it when OAuth is off
-		// or the flat source tool is inactive, instead of mistaking Pi's implicit
-		// activation for a user selection.
-		autoActivatedAliases.add(mcpName);
+		// Pi auto-activates newly registered tool NAMES (not same-name
+		// re-registrations, which preserve activation). Track only first-time
+		// registrations as auto-managed so syncAliasActivation can deactivate
+		// them when OAuth is off or the flat source tool is inactive, without
+		// flipping the provenance of a user-selected alias whose source schema
+		// merely changed.
+		if (isNewRegistration) {
+			autoActivatedAliases.add(mcpName);
+		}
 	};
 
 	// Aliasable tools, in deterministic order so collision suffixes are stable.
@@ -636,17 +648,22 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		})
 		.sort((a, b) => (lower(a.name) < lower(b.name) ? -1 : 1));
 
-	const derivedPairs: ToolAliasPair[] = [];
-	const seenFlat = new Set<string>();
+	// Exclude case-insensitive duplicate flat names entirely: all alias state
+	// is keyed by lowercased names, so aliasing either variant could route a
+	// call for one tool to the other (pi's execution lookup is exact-name).
+	const flatNameCounts = new Map<string, number>();
 	for (const tool of aliasable) {
 		const flatLc = lower(tool.name);
-		if (seenFlat.has(flatLc)) {
-			// Two registry tools differing only in case would share one alias slot;
-			// alias the first (sorted) one deterministically and skip the rest.
-			console.warn(`[pi-claude-code-use] Skipping alias for "${tool.name}": case-insensitive duplicate tool name`);
+		flatNameCounts.set(flatLc, (flatNameCounts.get(flatLc) ?? 0) + 1);
+	}
+
+	const derivedPairs: ToolAliasPair[] = [];
+	for (const tool of aliasable) {
+		const flatLc = lower(tool.name);
+		if ((flatNameCounts.get(flatLc) ?? 0) > 1) {
+			console.warn(`[pi-claude-code-use] Not aliasing "${tool.name}": case-insensitive duplicate tool name`);
 			continue;
 		}
-		seenFlat.add(flatLc);
 
 		const override = userOverrides.get(flatLc);
 		if (override) {
@@ -731,8 +748,12 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 
 		if (next.length !== activeNames.length || next.some((n, i) => n !== activeNames[i])) {
 			pi.setActiveTools(next);
-			lastManagedToolList = [...next];
 		}
+		// Record the managed state even when nothing changed (pi may have
+		// auto-activated a fresh alias, making the first sync a no-op). The
+		// promote-to-user-selected logic needs this baseline to recognize a
+		// user's later picker changes.
+		lastManagedToolList = [...next];
 	} else {
 		// Remove only auto-activated aliases; user-selected ones are preserved
 		const next = activeNames.filter((n) => !autoActivatedAliases.has(n));

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -1,27 +1,12 @@
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
-import * as piAgentCoreModule from "@earendil-works/pi-agent-core";
-import * as piAiModule from "@earendil-works/pi-ai";
-import * as piAiOauthModule from "@earendil-works/pi-ai/oauth";
-import * as piCodingAgentModule from "@earendil-works/pi-coding-agent";
+import { join } from "node:path";
 import { type ExtensionAPI, getAgentDir } from "@earendil-works/pi-coding-agent";
-import * as piTuiModule from "@earendil-works/pi-tui";
-import { createJiti } from "@mariozechner/jiti";
-import * as typeboxModule from "typebox";
-import * as typeboxCompileModule from "typebox/compile";
-import * as typeboxValueModule from "typebox/value";
 
 // ============================================================================
 // Types
 // ============================================================================
 
 type ToolAliasPair = readonly [flatName: string, mcpName: string];
-
-interface CompanionSpec {
-	dirName: string;
-	packageName: string;
-	aliases: ReadonlyArray<ToolAliasPair>;
-}
 
 type ToolRegistration = Parameters<ExtensionAPI["registerTool"]>[0];
 type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
@@ -33,7 +18,7 @@ type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
 /**
  * Core Claude Code tool names that always pass through Anthropic OAuth filtering.
  * Stored lowercase for case-insensitive matching.
- * Mirrors Pi core's claudeCodeTools list in packages/ai/src/providers/anthropic.ts
+ * Mirrors Pi core's claudeCodeTools list in packages/ai/src/api/anthropic-messages.ts
  */
 const CORE_TOOL_NAMES = new Set([
 	"read",
@@ -55,37 +40,17 @@ const CORE_TOOL_NAMES = new Set([
 	"websearch",
 ]);
 
-/** Known companion extensions and the tools they provide. */
-const COMPANIONS: CompanionSpec[] = [
-	{
-		dirName: "pi-exa-mcp",
-		packageName: "@benvargas/pi-exa-mcp",
-		aliases: [
-			["web_search_exa", "mcp__exa__web_search"],
-			["get_code_context_exa", "mcp__exa__get_code_context"],
-		],
-	},
-	{
-		dirName: "pi-firecrawl",
-		packageName: "@benvargas/pi-firecrawl",
-		aliases: [
-			["firecrawl_scrape", "mcp__firecrawl__scrape"],
-			["firecrawl_map", "mcp__firecrawl__map"],
-			["firecrawl_search", "mcp__firecrawl__search"],
-		],
-	},
-];
+/** Anthropic's maximum tool name length. */
+const MAX_TOOL_NAME_LENGTH = 128;
 
-/** Built-in flat companion tool name → MCP-style alias entries, derived from companion metadata. */
-const COMPANION_ALIAS_ENTRIES: ReadonlyArray<ToolAliasPair> = COMPANIONS.flatMap((spec) => spec.aliases);
+/** Generic build/source directory names skipped when deriving an alias server segment from a path. */
+const GENERIC_DIR_NAMES = new Set(["extensions", "src", "dist", "lib", "build", "out"]);
 
-/** Flat tool name → MCP-style alias. Rebuilt from built-in companions plus current user config. */
-const FLAT_TO_MCP = new Map<string, string>(COMPANION_ALIAS_ENTRIES);
+/** Flat tool name (lowercase) → MCP-style alias. Rebuilt on every alias registration pass. */
+const FLAT_TO_MCP = new Map<string, string>();
 
-/** Reverse lookup: flat tool name → its companion spec. */
-const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
-	COMPANIONS.flatMap((spec) => spec.aliases.map(([flat]) => [flat, spec] as const)),
-);
+/** Reverse map: MCP-prefixed alias (lowercase) → canonical flat name. Used by `unaliasToolCalls`. */
+const MCP_TO_FLAT = new Map<string, string>();
 
 // ============================================================================
 // User-defined tool aliases (pi-claude-code-use.json)
@@ -96,6 +61,10 @@ const TOOL_TO_COMPANION = new Map<string, CompanionSpec>(
 // Project file's keys replace global file's via spread-merge — same effective
 // behaviour as pi-core's deepMergeSettings for our top-level array key.
 // Schema: { "toolAliases": [[flat, mcp], ...] }
+//
+// Entries act as overrides on top of automatic alias derivation: when a flat
+// tool name appears here, the configured MCP name is used instead of the
+// derived one.
 // ============================================================================
 
 const CONFIG_FILENAME = "pi-claude-code-use.json";
@@ -146,24 +115,18 @@ function lower(name: string | undefined): string {
 	return (name ?? "").trim().toLowerCase();
 }
 
-function refreshAliasMap(userToolAliases: ToolAliasPair[]): void {
+function refreshAliasMap(userToolAliases: ToolAliasPair[], derivedPairs: ToolAliasPair[] = []): void {
 	FLAT_TO_MCP.clear();
 	MCP_TO_FLAT.clear();
-	for (const [flat, mcp] of COMPANION_ALIAS_ENTRIES) {
+	for (const [flat, mcp] of derivedPairs) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
 		MCP_TO_FLAT.set(lower(mcp), flat);
 	}
+	// User-configured aliases win over derived ones.
 	for (const [flat, mcp] of userToolAliases) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
 		MCP_TO_FLAT.set(lower(mcp), flat);
 	}
-}
-
-// Reverse map: MCP-prefixed alias (lowercase) → canonical flat name.
-// Populated alongside FLAT_TO_MCP. Used by `unaliasToolCalls`.
-const MCP_TO_FLAT = new Map<string, string>();
-for (const [flat, mcp] of COMPANION_ALIAS_ENTRIES) {
-	MCP_TO_FLAT.set(lower(mcp), flat);
 }
 
 // Rewrite `name` on every block of `blockType` via `mapName`. Returns the
@@ -191,7 +154,7 @@ function remapBlockNames(
 // back to their canonical flat names. Fires from `message_end`, which runs
 // BEFORE the agent loop resolves which tool to invoke — so Pi looks up the
 // ORIGINAL extension's `execute` (preserving its closure-bound state) instead
-// of pi-claude-code-use's jiti-loaded duplicate. Inverse of `remapMessageToolNames`.
+// of this extension's schema-only alias stub. Inverse of `remapMessageToolNames`.
 //
 // Gated on `registeredMcpAliases`: only rewrites names that this extension
 // explicitly registered, so foreign mcp__ tools (owned by other extensions)
@@ -245,8 +208,8 @@ function rewriteSystemField(system: unknown): unknown {
 // 1. Anthropic-native typed tools (have a `type` field) → pass through
 // 2. Core Claude Code tool names → pass through
 // 3. Tools already prefixed with mcp__ → pass through
-// 4. Known companion tools whose MCP alias is also advertised → rename to alias
-// 5. Known companion tools without an advertised alias → filtered out
+// 4. Aliased flat tools whose MCP alias is also advertised → rename to alias
+// 5. Aliased flat tools without an advertised alias → filtered out
 // 6. Unknown flat-named tools → filtered out (unless disableFilter)
 // ============================================================================
 
@@ -300,7 +263,7 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 			continue;
 		}
 
-		// Rules 4 & 5: known companion tool
+		// Rules 4 & 5: flat tool with a known MCP alias
 		const mcpAlias = FLAT_TO_MCP.get(nameLc);
 		if (mcpAlias) {
 			const aliasLc = lower(mcpAlias);
@@ -428,208 +391,204 @@ function writeDebugLog(payload: unknown): void {
 }
 
 // ============================================================================
-// Companion alias registration (PRD §1.3)
+// MCP alias derivation
 //
-// Discovers loaded companion extensions, captures their tool definitions via
-// a shim ExtensionAPI, and registers MCP-alias versions so Anthropic sees
-// Claude Code-compatible tool names. Managed alias tool calls are rewritten
-// back to their flat source names at `message_end` before Pi resolves execution.
+// Anthropic's OAuth subscription endpoint refuses flat-named custom tools but
+// accepts any name shaped like mcp__<server>__<tool>. Instead of maintaining a
+// hardcoded list of known extensions, every non-core flat tool reported by
+// pi.getAllTools() gets a deterministic MCP-style alias derived from its
+// sourceInfo (the extension it came from) and its tool name.
+// ============================================================================
+
+/** Sanitize a name fragment into a lowercase [a-z0-9_] segment. */
+function sanitizeAliasSegment(value: string, fallback: string): string {
+	const cleaned = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return cleaned.length > 0 ? cleaned : fallback;
+}
+
+/** Strip a leading "pi-"/"pi_" prefix from an extension/package name. */
+function stripPiPrefix(name: string): string {
+	return name.replace(/^pi[-_]/i, "");
+}
+
+/**
+ * Derive the `<server>` segment of an MCP alias from a tool's sourceInfo.
+ *
+ * Priority:
+ * 1. Synthetic sources (`<builtin:...>`, `<sdk:...>`) → "pi".
+ * 2. npm installs → unscoped package name from the node_modules path.
+ * 3. Single-file extensions → file stem (when not "index").
+ * 4. Directory-based extensions → nearest non-generic directory name
+ *    (skipping extensions/src/dist/lib/build/out), falling back to baseDir.
+ */
+function deriveServerSegment(sourceInfo: ToolInfo["sourceInfo"] | undefined): string {
+	const rawPath = (sourceInfo?.path ?? "").replaceAll("\\", "/");
+	if (!rawPath || rawPath.startsWith("<")) return "pi";
+
+	// npm install: use the package name from the node_modules path.
+	const nmIdx = rawPath.lastIndexOf("/node_modules/");
+	if (nmIdx !== -1) {
+		const segments = rawPath
+			.slice(nmIdx + "/node_modules/".length)
+			.split("/")
+			.filter(Boolean);
+		const pkg = segments[0]?.startsWith("@") ? segments[1] : segments[0];
+		if (pkg) return sanitizeAliasSegment(stripPiPrefix(pkg), "ext");
+	}
+
+	const segments = rawPath.split("/").filter(Boolean);
+	const fileName = segments.pop() ?? "";
+
+	// Single-file extension: use the file stem when it is meaningful.
+	const stem = fileName.replace(/\.[^.]*$/, "");
+	if (stem && stem !== "index") return sanitizeAliasSegment(stripPiPrefix(stem), "ext");
+
+	// Walk up past generic build/source directory names.
+	while (segments.length > 0 && GENERIC_DIR_NAMES.has(segments[segments.length - 1] ?? "")) {
+		segments.pop();
+	}
+	const dirName = segments[segments.length - 1];
+	if (dirName && !/^[a-zA-Z]:$/.test(dirName)) return sanitizeAliasSegment(stripPiPrefix(dirName), "ext");
+
+	return "ext";
+}
+
+/** Derive the base (pre-collision-handling) MCP alias for a tool. */
+function deriveAliasBase(tool: ToolInfo): string {
+	const server = deriveServerSegment(tool.sourceInfo);
+	const toolSegment = sanitizeAliasSegment(tool.name, "tool");
+	return `mcp__${server}__${toolSegment}`;
+}
+
+/**
+ * Resolve `base` against `taken` (lowercase name set), appending a numeric
+ * suffix (`_2`, `_3`, ...) on collision. The result always fits Anthropic's
+ * 128-char tool name limit. Deterministic for a given base + taken set.
+ */
+function reserveAliasName(base: string, taken: Set<string>): string {
+	let candidate = base.slice(0, MAX_TOOL_NAME_LENGTH);
+	let counter = 2;
+	while (taken.has(lower(candidate))) {
+		const suffix = `_${counter}`;
+		candidate = `${base.slice(0, MAX_TOOL_NAME_LENGTH - suffix.length)}${suffix}`;
+		counter += 1;
+	}
+	return candidate;
+}
+
+// ============================================================================
+// MCP alias registration
+//
+// At session start and before each agent turn, reads the live tool registry
+// via pi.getAllTools() and registers a schema-only MCP alias for every
+// non-core flat tool. This includes tools that other extensions register from
+// lifecycle hooks (e.g. pi-web-providers), which a static capture of the
+// extension factory would miss.
+//
+// Alias tools carry the source tool's schema, description, and prompt
+// guidelines, but a stub execute: managed alias calls are rewritten back to
+// their flat source names at `message_end` before Pi resolves execution, so
+// the ORIGINAL extension's execute always runs.
 // ============================================================================
 
 const registeredMcpAliases = new Set<string>();
 const autoActivatedAliases = new Set<string>();
 let lastManagedToolList: string[] | undefined;
 
-const captureCache = new Map<string, Promise<Map<string, ToolRegistration>>>();
-let jitiLoader: { import(path: string, opts?: { default?: boolean }): Promise<unknown> } | undefined;
+/** flat tool name (lowercase) → assigned MCP alias. Keeps assignments stable within a session. */
+const aliasAssignments = new Map<string, string>();
 
-function getJitiLoader() {
-	if (!jitiLoader) {
-		jitiLoader = createJiti(import.meta.url, {
-			moduleCache: false,
-			tryNative: false,
-			virtualModules: {
-				"@earendil-works/pi-agent-core": piAgentCoreModule,
-				"@earendil-works/pi-ai": piAiModule,
-				"@earendil-works/pi-ai/oauth": piAiOauthModule,
-				"@earendil-works/pi-coding-agent": piCodingAgentModule,
-				"@earendil-works/pi-tui": piTuiModule,
-				"@mariozechner/pi-agent-core": piAgentCoreModule,
-				"@mariozechner/pi-ai": piAiModule,
-				"@mariozechner/pi-ai/oauth": piAiOauthModule,
-				"@mariozechner/pi-coding-agent": piCodingAgentModule,
-				"@mariozechner/pi-tui": piTuiModule,
-				typebox: typeboxModule,
-				"typebox/compile": typeboxCompileModule,
-				"typebox/value": typeboxValueModule,
-				"@sinclair/typebox": typeboxModule,
-				"@sinclair/typebox/compile": typeboxCompileModule,
-				"@sinclair/typebox/value": typeboxValueModule,
-			},
-		});
-	}
-	return jitiLoader;
-}
-
-async function loadFactory(baseDir: string): Promise<((pi: ExtensionAPI) => void | Promise<void>) | undefined> {
-	const dir = baseDir.replace(/\/$/, "");
-	const candidates = [`${dir}/index.ts`, `${dir}/index.js`, `${dir}/extensions/index.ts`, `${dir}/extensions/index.js`];
-
-	const loader = getJitiLoader();
-	for (const path of candidates) {
-		try {
-			const mod = await loader.import(path, { default: true });
-			if (typeof mod === "function") return mod as (pi: ExtensionAPI) => void | Promise<void>;
-		} catch {
-			// Try next candidate
-		}
-	}
-	return undefined;
-}
-
-function isCompanionSource(tool: ToolInfo | undefined, spec: CompanionSpec): boolean {
-	if (!tool?.sourceInfo) return false;
-
-	const baseDir = tool.sourceInfo.baseDir;
-	if (baseDir) {
-		const dirName = basename(baseDir);
-		if (dirName === spec.dirName) return true;
-		if (dirName === "extensions" && basename(dirname(baseDir)) === spec.dirName) return true;
-	}
-
-	const fullPath = tool.sourceInfo.path;
-	if (typeof fullPath !== "string") return false;
-	// Normalize backslashes for Windows paths before segment-bounded check
-	const normalized = fullPath.replaceAll("\\", "/");
-	// Check for scoped package name (npm install) or directory name (git/monorepo)
-	return normalized.includes(`/${spec.packageName}/`) || normalized.includes(`/${spec.dirName}/`);
-}
-
-function buildCaptureShim(realPi: ExtensionAPI, captured: Map<string, ToolRegistration>): ExtensionAPI {
-	const shimFlags = new Set<string>();
-	return {
-		registerTool(def) {
-			captured.set(def.name, def as unknown as ToolRegistration);
-		},
-		registerFlag(name, _options) {
-			shimFlags.add(name);
-		},
-		getFlag(name) {
-			return shimFlags.has(name) ? realPi.getFlag(name) : undefined;
-		},
-		on() {},
-		registerCommand() {},
-		registerShortcut() {},
-		registerMessageRenderer() {},
-		// Tool capture must not duplicate display-only renderer registrations.
-		registerEntryRenderer() {},
-		registerProvider() {},
-		unregisterProvider() {},
-		sendMessage() {},
-		sendUserMessage() {},
-		appendEntry() {},
-		setSessionName() {},
-		getSessionName() {
-			return undefined;
-		},
-		setLabel() {},
-		exec(command, args, options) {
-			return realPi.exec(command, args, options);
-		},
-		getActiveTools() {
-			return realPi.getActiveTools();
-		},
-		getAllTools() {
-			return realPi.getAllTools();
-		},
-		setActiveTools(names) {
-			realPi.setActiveTools(names);
-		},
-		getCommands() {
-			return realPi.getCommands();
-		},
-		setModel(model) {
-			return realPi.setModel(model);
-		},
-		getThinkingLevel() {
-			return realPi.getThinkingLevel();
-		},
-		setThinkingLevel(level) {
-			realPi.setThinkingLevel(level);
-		},
-		events: realPi.events,
-	} satisfies ExtensionAPI;
-}
-
-async function captureCompanionTools(baseDir: string, realPi: ExtensionAPI): Promise<Map<string, ToolRegistration>> {
-	let pending = captureCache.get(baseDir);
-	if (!pending) {
-		pending = (async () => {
-			const factory = await loadFactory(baseDir);
-			if (!factory) return new Map<string, ToolRegistration>();
-			const tools = new Map<string, ToolRegistration>();
-			await factory(buildCaptureShim(realPi, tools));
-			return tools;
-		})();
-		captureCache.set(baseDir, pending);
-	}
-	return pending;
-}
-
-async function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: string } = {}): Promise<void> {
-	// Clear capture cache so flag/config changes since last call take effect
-	captureCache.clear();
-
-	// Pick up user-defined tool aliases from settings.json so subsequent payload
-	// transforms (filterAndRemapTools, remapToolChoice, message rewriting) see them.
+function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: string } = {}): void {
+	// Pick up user-defined tool aliases so subsequent payload transforms
+	// (filterAndRemapTools, remapToolChoice, message rewriting) see them.
 	const userToolAliases = loadToolAliases(opts.cwd ?? process.cwd(), opts.agentDir);
-	refreshAliasMap(userToolAliases);
+	const disableAutoAlias = process.env.PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS === "1";
 
 	const allTools = pi.getAllTools();
 	const toolIndex = new Map<string, ToolInfo>();
-	const knownNames = new Set<string>();
 	for (const tool of allTools) {
 		toolIndex.set(lower(tool.name), tool);
-		knownNames.add(lower(tool.name));
 	}
 
-	// Loads the source extension via jiti and re-registers its captured tool
-	// definition under `mcpName`. Skips if already registered or unloadable.
-	const registerMcpAlias = async (tool: ToolInfo | undefined, flatName: string, mcpName: string): Promise<void> => {
-		if (!tool || registeredMcpAliases.has(lower(mcpName)) || knownNames.has(lower(mcpName))) return;
-		// Prefer the extension file's directory (sourceInfo.path is the actual entry
-		// point). Fall back to baseDir, which can be the monorepo root.
-		const loadDir = tool.sourceInfo?.path ? dirname(tool.sourceInfo.path) : tool.sourceInfo?.baseDir;
-		if (!loadDir) return;
-		const def = (await captureCompanionTools(loadDir, pi)).get(flatName);
-		if (!def) return;
+	// Names unavailable for newly derived aliases: every currently registered
+	// tool plus every user-configured alias target.
+	const taken = new Set(toolIndex.keys());
+
+	const userOverrides = new Map<string, string>();
+	for (const [flat, mcp] of userToolAliases) {
+		if (!lower(mcp).startsWith("mcp__")) {
+			console.warn(
+				`[pi-claude-code-use] Ignoring toolAliases entry ["${flat}", "${mcp}"]: alias must start with "mcp__"`,
+			);
+			continue;
+		}
+		userOverrides.set(lower(flat), mcp);
+		taken.add(lower(mcp));
+	}
+
+	const registerAliasTool = (tool: ToolInfo, mcpName: string): void => {
+		const mcpLc = lower(mcpName);
+		if (registeredMcpAliases.has(mcpLc)) return;
+		// Never shadow an existing tool (e.g. a real MCP tool from another extension).
+		if (toolIndex.has(mcpLc)) return;
 		pi.registerTool({
-			...def,
 			name: mcpName,
-			label: def.label?.startsWith("MCP ") ? def.label : `MCP ${def.label ?? mcpName}`,
-		});
-		registeredMcpAliases.add(lower(mcpName));
-		knownNames.add(lower(mcpName));
+			label: `MCP ${tool.name}`,
+			description: tool.description,
+			parameters: tool.parameters,
+			...(tool.promptGuidelines ? { promptGuidelines: tool.promptGuidelines } : {}),
+			async execute() {
+				// Managed alias calls are rewritten back to the flat tool name at
+				// message_end before Pi resolves execution, so this stub only runs
+				// if that rewrite was somehow bypassed.
+				throw new Error(
+					`Tool alias "${mcpName}" was invoked directly; pi-claude-code-use should have routed it to "${tool.name}".`,
+				);
+			},
+		} as ToolRegistration);
+		registeredMcpAliases.add(mcpLc);
 	};
 
-	// Built-in companion aliases: gated by source-info match against COMPANIONS.
-	for (const spec of COMPANIONS) {
-		for (const [flatName, mcpName] of spec.aliases) {
-			const tool = toolIndex.get(lower(flatName));
-			if (tool && !isCompanionSource(tool, spec)) continue;
-			await registerMcpAlias(tool, flatName, mcpName);
+	// Aliasable tools, in deterministic order so collision suffixes are stable.
+	const aliasable = allTools
+		.filter((tool) => {
+			const nameLc = lower(tool.name);
+			return nameLc.length > 0 && !CORE_TOOL_NAMES.has(nameLc) && !nameLc.startsWith("mcp__");
+		})
+		.sort((a, b) => (lower(a.name) < lower(b.name) ? -1 : 1));
+
+	const derivedPairs: ToolAliasPair[] = [];
+	for (const tool of aliasable) {
+		const flatLc = lower(tool.name);
+
+		const override = userOverrides.get(flatLc);
+		if (override) {
+			aliasAssignments.set(flatLc, override);
+			registerAliasTool(tool, override);
+			continue; // Mapping comes from userToolAliases in refreshAliasMap.
 		}
+		if (disableAutoAlias) continue;
+
+		// Reuse the previous assignment when we registered it; otherwise derive.
+		let mcpName = aliasAssignments.get(flatLc);
+		if (!mcpName || (!registeredMcpAliases.has(lower(mcpName)) && taken.has(lower(mcpName)))) {
+			mcpName = reserveAliasName(deriveAliasBase(tool), taken);
+		}
+		taken.add(lower(mcpName));
+		aliasAssignments.set(flatLc, mcpName);
+		derivedPairs.push([tool.name, mcpName]);
+		registerAliasTool(tool, mcpName);
 	}
 
-	// User-defined aliases: matched by flat name only.
-	for (const [flatName, mcpName] of userToolAliases) {
-		await registerMcpAlias(toolIndex.get(lower(flatName)), flatName, mcpName);
-	}
+	refreshAliasMap(userToolAliases, derivedPairs);
 }
 
 /**
  * Synchronize MCP alias tool activation with the current model state.
- * When OAuth is active, auto-activate aliases for any active companion tools.
+ * When OAuth is active, auto-activate aliases for any active flat source tools.
  * When OAuth is inactive, remove auto-activated aliases (but preserve user-selected ones).
  */
 function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
@@ -711,11 +670,11 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 
 export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
 	pi.on("session_start", async (_event, ctx) => {
-		await registerMcpAliases(pi, { cwd: ctx.cwd });
+		registerMcpAliases(pi, { cwd: ctx.cwd });
 	});
 
 	pi.on("before_agent_start", async (_event, ctx) => {
-		await registerMcpAliases(pi, { cwd: ctx.cwd });
+		registerMcpAliases(pi, { cwd: ctx.cwd });
 		const model = ctx.model;
 		const isOAuth = model?.provider === "anthropic" && ctx.modelRegistry.isUsingOAuth(model);
 		syncAliasActivation(pi, isOAuth);
@@ -753,15 +712,14 @@ export const _test = {
 	CORE_TOOL_NAMES,
 	MCP_TO_FLAT,
 	FLAT_TO_MCP,
-	COMPANIONS,
-	TOOL_TO_COMPANION,
+	aliasAssignments,
 	autoActivatedAliases,
-	buildCaptureShim,
 	collectToolNames,
+	deriveAliasBase,
+	deriveServerSegment,
 	extractToolAliasPairs,
 	filterAndRemapTools,
 	getLastManagedToolList: () => lastManagedToolList,
-	isCompanionSource,
 	isPlainObject,
 	loadToolAliases,
 	lower,
@@ -770,8 +728,10 @@ export const _test = {
 	registeredMcpAliases,
 	remapMessageToolNames,
 	remapToolChoice,
+	reserveAliasName,
 	rewritePromptText,
 	rewriteSystemField,
+	sanitizeAliasSegment,
 	setLastManagedToolList: (v: string[] | undefined) => {
 		lastManagedToolList = v;
 	},

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -244,6 +244,26 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 	const emitted = new Set<string>();
 	const result: unknown[] = [];
 
+	// Aliases (lowercase) that a flat entry in this payload will be renamed to.
+	// A standalone advertised alias stub is suppressed in favor of the renamed
+	// flat entry regardless of payload order, because the flat entry always
+	// carries the source tool's current schema.
+	const replacedByFlat = new Set<string>();
+	if (!disableFilter) {
+		for (const tool of tools) {
+			if (!isPlainObject(tool) || typeof tool.name !== "string") continue;
+			if (typeof tool.type === "string" && tool.type.trim().length > 0) continue;
+			const nameLc = lower(tool.name);
+			if (CORE_TOOL_NAMES.has(nameLc) || nameLc.startsWith("mcp__")) continue;
+			const mcpAlias = FLAT_TO_MCP.get(nameLc);
+			if (!mcpAlias) continue;
+			const aliasLc = lower(mcpAlias);
+			if (advertised.has(aliasLc) || registeredMcpAliases.has(aliasLc)) {
+				replacedByFlat.add(aliasLc);
+			}
+		}
+	}
+
 	for (const tool of tools) {
 		if (!isPlainObject(tool)) continue;
 
@@ -257,9 +277,11 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 		if (!name) continue;
 		const nameLc = lower(name);
 
-		// Rules 2 & 3: core tools and mcp__-prefixed pass through (with dedup)
+		// Rules 2 & 3: core tools and mcp__-prefixed pass through (with dedup).
+		// Alias stubs that a flat entry will replace are skipped here; the
+		// renamed flat entry is emitted at the flat entry's position instead.
 		if (CORE_TOOL_NAMES.has(nameLc) || nameLc.startsWith("mcp__")) {
-			if (!emitted.has(nameLc)) {
+			if (!emitted.has(nameLc) && !replacedByFlat.has(nameLc)) {
 				emitted.add(nameLc);
 				result.push(tool);
 			}
@@ -526,6 +548,30 @@ interface AliasSourceMeta {
 }
 const aliasSourceMeta = new Map<string, AliasSourceMeta>();
 
+/** alias name (lowercase) → the EXACT alias name last registered with pi. Pi keys registrations by exact name, so a case-only change introduces (and auto-activates) a new tool name. */
+const aliasExactNames = new Map<string, string>();
+
+/**
+ * Promote auto-activated aliases to user-selected when the user deliberately
+ * kept the alias while removing its flat counterpart from the tool picker.
+ * Detected via the last managed baseline: the flat tool was previously
+ * managed, is no longer active, and the alias is still active. Comparisons
+ * are case-insensitive (FLAT_TO_MCP keys are lowercased; pi names are exact).
+ */
+function promoteKeptAliases(activeNames: string[], desiredSet: ReadonlySet<string>): void {
+	if (lastManagedToolList === undefined) return;
+	const activeSet = new Set(activeNames);
+	const activeLc = new Set(activeNames.map(lower));
+	const lastManagedLc = new Set(lastManagedToolList.map(lower));
+	for (const alias of [...autoActivatedAliases]) {
+		if (!activeSet.has(alias) || desiredSet.has(alias)) continue;
+		const flatLc = [...FLAT_TO_MCP.entries()].find(([, mcp]) => mcp === alias)?.[0];
+		if (flatLc && lastManagedLc.has(flatLc) && !activeLc.has(flatLc)) {
+			autoActivatedAliases.delete(alias);
+		}
+	}
+}
+
 function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: string } = {}): void {
 	// Pick up user-defined tool aliases so subsequent payload transforms
 	// (filterAndRemapTools, remapToolChoice, message rewriting) see them.
@@ -542,6 +588,25 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 	// tool plus every valid user-configured alias target.
 	const taken = new Set(toolIndex.keys());
 
+	// Aliasable tools, in deterministic order so collision suffixes are stable.
+	const aliasable = allTools
+		.filter((tool) => {
+			const nameLc = lower(tool.name);
+			return nameLc.length > 0 && !CORE_TOOL_NAMES.has(nameLc) && !nameLc.startsWith("mcp__");
+		})
+		.sort((a, b) => (lower(a.name) < lower(b.name) ? -1 : 1));
+
+	// Case-insensitive duplicate flat names are excluded from aliasing (and
+	// from user overrides): all alias state is keyed by lowercased names while
+	// pi's execution lookup is exact-name, so aliasing either variant could
+	// route a call for one tool to the other.
+	const flatNameCounts = new Map<string, number>();
+	for (const tool of aliasable) {
+		const flatLc = lower(tool.name);
+		flatNameCounts.set(flatLc, (flatNameCounts.get(flatLc) ?? 0) + 1);
+	}
+	const isDuplicateFlat = (flatLc: string): boolean => (flatNameCounts.get(flatLc) ?? 0) > 1;
+
 	// Validate user overrides. Invalid entries are fully ignored: they are
 	// excluded from registration AND from the alias maps, so derivation and
 	// payload remapping fall back to the derived alias.
@@ -553,6 +618,10 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 	const overrideTargets = new Set<string>();
 	for (const [flat, mcp] of userToolAliases) {
 		const mcpLc = lower(mcp);
+		if (isDuplicateFlat(lower(flat))) {
+			warnIgnored(flat, mcp, "flat tool name has a case-insensitive duplicate in the registry");
+			continue;
+		}
 		if (mcp !== mcp.trim()) {
 			warnIgnored(flat, mcp, "alias has surrounding whitespace");
 			continue;
@@ -596,13 +665,15 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		};
 		if (registeredMcpAliases.has(mcpLc)) {
 			// Re-register when the source tool's metadata changed (e.g. the source
-			// extension re-registered it with a new schema from a lifecycle hook).
+			// extension re-registered it with a new schema from a lifecycle hook)
+			// or when the exact alias casing changed (pi keys tools by exact name).
 			const previous = aliasSourceMeta.get(mcpLc);
 			if (
 				previous &&
 				previous.description === meta.description &&
 				previous.parameters === meta.parameters &&
-				previous.promptGuidelines === meta.promptGuidelines
+				previous.promptGuidelines === meta.promptGuidelines &&
+				aliasExactNames.get(mcpLc) === mcpName
 			) {
 				return;
 			}
@@ -610,7 +681,10 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 			// Never shadow an existing tool (e.g. a real MCP tool from another extension).
 			return;
 		}
-		const isNewRegistration = !registeredMcpAliases.has(mcpLc);
+		// Pi keys tool registrations by EXACT name and auto-activates newly
+		// introduced exact names, so a case-only alias change also counts as a
+		// new registration for provenance tracking.
+		const isNewExactName = aliasExactNames.get(mcpLc) !== mcpName;
 		pi.registerTool({
 			name: mcpName,
 			label: `MCP ${tool.name}`,
@@ -629,38 +703,21 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		registeredMcpAliases.add(mcpLc);
 		registeredAliasRoutes.set(mcpLc, tool.name);
 		aliasSourceMeta.set(mcpLc, meta);
+		aliasExactNames.set(mcpLc, mcpName);
 		// Pi auto-activates newly registered tool NAMES (not same-name
-		// re-registrations, which preserve activation). Track only first-time
-		// registrations as auto-managed so syncAliasActivation can deactivate
-		// them when OAuth is off or the flat source tool is inactive, without
-		// flipping the provenance of a user-selected alias whose source schema
-		// merely changed.
-		if (isNewRegistration) {
+		// re-registrations, which preserve activation). Track only new exact
+		// names as auto-managed so syncAliasActivation can deactivate them when
+		// OAuth is off or the flat source tool is inactive, without flipping the
+		// provenance of a user-selected alias whose source schema merely changed.
+		if (isNewExactName) {
 			autoActivatedAliases.add(mcpName);
 		}
 	};
 
-	// Aliasable tools, in deterministic order so collision suffixes are stable.
-	const aliasable = allTools
-		.filter((tool) => {
-			const nameLc = lower(tool.name);
-			return nameLc.length > 0 && !CORE_TOOL_NAMES.has(nameLc) && !nameLc.startsWith("mcp__");
-		})
-		.sort((a, b) => (lower(a.name) < lower(b.name) ? -1 : 1));
-
-	// Exclude case-insensitive duplicate flat names entirely: all alias state
-	// is keyed by lowercased names, so aliasing either variant could route a
-	// call for one tool to the other (pi's execution lookup is exact-name).
-	const flatNameCounts = new Map<string, number>();
-	for (const tool of aliasable) {
-		const flatLc = lower(tool.name);
-		flatNameCounts.set(flatLc, (flatNameCounts.get(flatLc) ?? 0) + 1);
-	}
-
 	const derivedPairs: ToolAliasPair[] = [];
 	for (const tool of aliasable) {
 		const flatLc = lower(tool.name);
-		if ((flatNameCounts.get(flatLc) ?? 0) > 1) {
+		if (isDuplicateFlat(flatLc)) {
 			console.warn(`[pi-claude-code-use] Not aliasing "${tool.name}": case-insensitive duplicate tool name`);
 			continue;
 		}
@@ -706,24 +763,7 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		}
 		const desiredSet = new Set(desiredAliases);
 
-		// Promote auto-activated aliases to user-selected when the user explicitly kept
-		// the alias while removing its flat counterpart from the tool picker.
-		// We detect this by checking: (a) user changed the tool list since our last sync,
-		// (b) the flat tool was previously managed but is no longer active, and
-		// (c) the alias is still active. This means the user deliberately kept the alias.
-		if (lastManagedToolList !== undefined) {
-			const activeSet = new Set(activeNames);
-			const lastManaged = new Set(lastManagedToolList);
-			for (const alias of autoActivatedAliases) {
-				if (!activeSet.has(alias) || desiredSet.has(alias)) continue;
-				// Find the flat name for this alias
-				const flatName = [...FLAT_TO_MCP.entries()].find(([, mcp]) => mcp === alias)?.[0];
-				if (flatName && lastManaged.has(flatName) && !activeSet.has(flatName)) {
-					// User removed the flat tool but kept the alias → promote to user-selected
-					autoActivatedAliases.delete(alias);
-				}
-			}
-		}
+		promoteKeptAliases(activeNames, desiredSet);
 
 		// Find registered aliases currently in the active list
 		const activeRegistered = activeNames.filter((n) => registeredMcpAliases.has(lower(n)) && allNames.has(n));
@@ -755,6 +795,11 @@ function syncAliasActivation(pi: ExtensionAPI, enableAliases: boolean): void {
 		// user's later picker changes.
 		lastManagedToolList = [...next];
 	} else {
+		// A user may have removed a flat tool while keeping its alias and then
+		// switched away from OAuth before another enabled sync ran; honor that
+		// choice here too before pruning.
+		promoteKeptAliases(activeNames, new Set());
+
 		// Remove only auto-activated aliases; user-selected ones are preserved
 		const next = activeNames.filter((n) => !autoActivatedAliases.has(n));
 		autoActivatedAliases.clear();
@@ -827,6 +872,7 @@ export const _test = {
 	MCP_TO_FLAT,
 	FLAT_TO_MCP,
 	aliasAssignments,
+	aliasExactNames,
 	aliasSourceMeta,
 	autoActivatedAliases,
 	registeredAliasRoutes,

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -164,9 +164,12 @@ function unaliasToolCalls(message: unknown): unknown {
 		return undefined;
 	}
 	const content = remapBlockNames(message.content, "toolCall", (n) => {
-		const flat = MCP_TO_FLAT.get(lower(n));
-		if (!flat || !registeredMcpAliases.has(lower(n))) return undefined;
-		return flat;
+		const nameLc = lower(n);
+		if (!registeredMcpAliases.has(nameLc)) return undefined;
+		// Prefer the current mapping; fall back to the permanent route recorded at
+		// registration time so stale aliases (e.g. after a config change removed
+		// their mapping) still resolve to their original flat tool.
+		return MCP_TO_FLAT.get(nameLc) ?? registeredAliasRoutes.get(nameLc);
 	});
 	return content === message.content ? undefined : { ...message, content };
 }
@@ -263,12 +266,16 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 			continue;
 		}
 
-		// Rules 4 & 5: flat tool with a known MCP alias
+		// Rules 4 & 5: flat tool with a known MCP alias. The alias qualifies when
+		// it is advertised in this payload OR when this extension registered it
+		// (covers aliases registered mid-turn, before activation catches up —
+		// message_end unaliasing routes the call to the flat tool either way).
 		const mcpAlias = FLAT_TO_MCP.get(nameLc);
 		if (mcpAlias) {
 			const aliasLc = lower(mcpAlias);
-			if (advertised.has(aliasLc) && !emitted.has(aliasLc)) {
-				// Alias exists in tool list -> preserve its metadata, including cache_control.
+			if ((advertised.has(aliasLc) || registeredMcpAliases.has(aliasLc)) && !emitted.has(aliasLc)) {
+				// Prefer the advertised alias entry to preserve its metadata,
+				// including cache_control; otherwise rename the flat entry.
 				emitted.add(aliasLc);
 				result.push(toolsByName.get(aliasLc) ?? { ...tool, name: mcpAlias });
 			} else if (disableFilter && !emitted.has(nameLc)) {
@@ -498,8 +505,19 @@ const registeredMcpAliases = new Set<string>();
 const autoActivatedAliases = new Set<string>();
 let lastManagedToolList: string[] | undefined;
 
-/** flat tool name (lowercase) → assigned MCP alias. Keeps assignments stable within a session. */
+/** flat tool name (lowercase) → auto-derived MCP alias. Keeps derived assignments stable within a session. User overrides are intentionally NOT stored here so removing an override reverts to derivation. */
 const aliasAssignments = new Map<string, string>();
+
+/** Permanent record: alias name (lowercase) → flat source tool name, for every alias this extension registered. Never cleared, so stale aliases keep resolving after config changes. */
+const registeredAliasRoutes = new Map<string, string>();
+
+/** alias name (lowercase) → source metadata snapshot used at registration, to detect source schema updates. */
+interface AliasSourceMeta {
+	description: string;
+	parameters: unknown;
+	promptGuidelines: unknown;
+}
+const aliasSourceMeta = new Map<string, AliasSourceMeta>();
 
 function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: string } = {}): void {
 	// Pick up user-defined tool aliases so subsequent payload transforms
@@ -514,26 +532,77 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 	}
 
 	// Names unavailable for newly derived aliases: every currently registered
-	// tool plus every user-configured alias target.
+	// tool plus every valid user-configured alias target.
 	const taken = new Set(toolIndex.keys());
 
+	// Validate user overrides. Invalid entries are fully ignored: they are
+	// excluded from registration AND from the alias maps, so derivation and
+	// payload remapping fall back to the derived alias.
+	const warnIgnored = (flat: string, mcp: string, reason: string): void => {
+		console.warn(`[pi-claude-code-use] Ignoring toolAliases entry ["${flat}", "${mcp}"]: ${reason}`);
+	};
+	const validUserAliases: ToolAliasPair[] = [];
 	const userOverrides = new Map<string, string>();
+	const overrideTargets = new Set<string>();
 	for (const [flat, mcp] of userToolAliases) {
-		if (!lower(mcp).startsWith("mcp__")) {
-			console.warn(
-				`[pi-claude-code-use] Ignoring toolAliases entry ["${flat}", "${mcp}"]: alias must start with "mcp__"`,
-			);
+		const mcpLc = lower(mcp);
+		if (mcp !== mcp.trim()) {
+			warnIgnored(flat, mcp, "alias has surrounding whitespace");
 			continue;
 		}
+		if (!mcpLc.startsWith("mcp__")) {
+			warnIgnored(flat, mcp, 'alias must start with "mcp__"');
+			continue;
+		}
+		if (mcp.length > MAX_TOOL_NAME_LENGTH) {
+			warnIgnored(flat, mcp, `alias exceeds ${MAX_TOOL_NAME_LENGTH} characters`);
+			continue;
+		}
+		if (overrideTargets.has(mcpLc)) {
+			warnIgnored(flat, mcp, "alias is already used by another toolAliases entry");
+			continue;
+		}
+		// The target may already exist as a tool only when this extension
+		// registered it for the same flat tool. A foreign tool with that name, or
+		// an alias we registered for a DIFFERENT flat tool, must not be re-routed.
+		const ownedFor = registeredAliasRoutes.get(mcpLc);
+		if (toolIndex.has(mcpLc) && !registeredMcpAliases.has(mcpLc)) {
+			warnIgnored(flat, mcp, "alias name is already taken by another extension's tool");
+			continue;
+		}
+		if (ownedFor !== undefined && lower(ownedFor) !== lower(flat)) {
+			warnIgnored(flat, mcp, `alias is already registered for "${ownedFor}"`);
+			continue;
+		}
+		validUserAliases.push([flat, mcp]);
 		userOverrides.set(lower(flat), mcp);
-		taken.add(lower(mcp));
+		overrideTargets.add(mcpLc);
+		taken.add(mcpLc);
 	}
 
 	const registerAliasTool = (tool: ToolInfo, mcpName: string): void => {
 		const mcpLc = lower(mcpName);
-		if (registeredMcpAliases.has(mcpLc)) return;
-		// Never shadow an existing tool (e.g. a real MCP tool from another extension).
-		if (toolIndex.has(mcpLc)) return;
+		const meta: AliasSourceMeta = {
+			description: tool.description,
+			parameters: tool.parameters,
+			promptGuidelines: tool.promptGuidelines,
+		};
+		if (registeredMcpAliases.has(mcpLc)) {
+			// Re-register when the source tool's metadata changed (e.g. the source
+			// extension re-registered it with a new schema from a lifecycle hook).
+			const previous = aliasSourceMeta.get(mcpLc);
+			if (
+				previous &&
+				previous.description === meta.description &&
+				previous.parameters === meta.parameters &&
+				previous.promptGuidelines === meta.promptGuidelines
+			) {
+				return;
+			}
+		} else if (toolIndex.has(mcpLc)) {
+			// Never shadow an existing tool (e.g. a real MCP tool from another extension).
+			return;
+		}
 		pi.registerTool({
 			name: mcpName,
 			label: `MCP ${tool.name}`,
@@ -550,6 +619,13 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 			},
 		} as ToolRegistration);
 		registeredMcpAliases.add(mcpLc);
+		registeredAliasRoutes.set(mcpLc, tool.name);
+		aliasSourceMeta.set(mcpLc, meta);
+		// Pi auto-activates newly registered tools. Track the alias as
+		// auto-managed so syncAliasActivation can deactivate it when OAuth is off
+		// or the flat source tool is inactive, instead of mistaking Pi's implicit
+		// activation for a user selection.
+		autoActivatedAliases.add(mcpName);
 	};
 
 	// Aliasable tools, in deterministic order so collision suffixes are stable.
@@ -561,18 +637,25 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		.sort((a, b) => (lower(a.name) < lower(b.name) ? -1 : 1));
 
 	const derivedPairs: ToolAliasPair[] = [];
+	const seenFlat = new Set<string>();
 	for (const tool of aliasable) {
 		const flatLc = lower(tool.name);
+		if (seenFlat.has(flatLc)) {
+			// Two registry tools differing only in case would share one alias slot;
+			// alias the first (sorted) one deterministically and skip the rest.
+			console.warn(`[pi-claude-code-use] Skipping alias for "${tool.name}": case-insensitive duplicate tool name`);
+			continue;
+		}
+		seenFlat.add(flatLc);
 
 		const override = userOverrides.get(flatLc);
 		if (override) {
-			aliasAssignments.set(flatLc, override);
 			registerAliasTool(tool, override);
-			continue; // Mapping comes from userToolAliases in refreshAliasMap.
+			continue; // Mapping comes from validUserAliases in refreshAliasMap.
 		}
 		if (disableAutoAlias) continue;
 
-		// Reuse the previous assignment when we registered it; otherwise derive.
+		// Reuse the previous derived assignment when we registered it; otherwise derive.
 		let mcpName = aliasAssignments.get(flatLc);
 		if (!mcpName || (!registeredMcpAliases.has(lower(mcpName)) && taken.has(lower(mcpName)))) {
 			mcpName = reserveAliasName(deriveAliasBase(tool), taken);
@@ -583,7 +666,7 @@ function registerMcpAliases(pi: ExtensionAPI, opts: { cwd?: string; agentDir?: s
 		registerAliasTool(tool, mcpName);
 	}
 
-	refreshAliasMap(userToolAliases, derivedPairs);
+	refreshAliasMap(validUserAliases, derivedPairs);
 }
 
 /**
@@ -696,6 +779,16 @@ export default async function piClaudeCodeUse(pi: ExtensionAPI): Promise<void> {
 			return undefined;
 		}
 
+		// Catch tools registered by other extensions' before_agent_start handlers
+		// that ran AFTER ours (extension order), so their aliases exist on the
+		// first turn instead of the second. filterAndRemapTools renames flat tools
+		// to registered aliases even before activation catches up.
+		try {
+			registerMcpAliases(pi, { cwd: typeof ctx.cwd === "string" ? ctx.cwd : undefined });
+		} catch {
+			// Alias refresh must never break the actual request.
+		}
+
 		writeDebugLog({ stage: "before", payload: event.payload });
 		const disableFilter = process.env.PI_CLAUDE_CODE_USE_DISABLE_TOOL_FILTER === "1";
 		const transformed = transformPayload(event.payload as Record<string, unknown>, disableFilter);
@@ -713,7 +806,9 @@ export const _test = {
 	MCP_TO_FLAT,
 	FLAT_TO_MCP,
 	aliasAssignments,
+	aliasSourceMeta,
 	autoActivatedAliases,
+	registeredAliasRoutes,
 	collectToolNames,
 	deriveAliasBase,
 	deriveServerSegment,

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.77.0"
   },
   "repository": {
     "type": "git",

--- a/packages/pi-claude-code-use/package.json
+++ b/packages/pi-claude-code-use/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@benvargas/pi-claude-code-use",
-  "version": "1.0.5",
-  "description": "Patch Anthropic OAuth payloads and companion tools for Claude Code-style subscription use",
+  "version": "2.0.0",
+  "description": "Patch Anthropic OAuth payloads and auto-alias extension tools for Claude Code-style subscription use",
   "keywords": [
     "pi",
     "pi-package",
@@ -24,15 +24,8 @@
       "./extensions/index.ts"
     ]
   },
-  "dependencies": {
-    "@mariozechner/jiti": "^2.6.5"
-  },
   "peerDependencies": {
-    "@earendil-works/pi-agent-core": ">=0.74.0",
-    "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-tui": ">=0.74.0",
-    "typebox": "*"
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Replaces the hardcoded `COMPANIONS` list and jiti-based extension-factory capture with dynamic MCP alias derivation driven by `pi.getAllTools()`. Every non-core flat tool in Pi's live registry now gets a deterministic `mcp__<server>__<tool>` alias derived from its `sourceInfo` — including tools that other extensions register from **lifecycle hooks** (e.g. `pi-web-providers`' managed `web_search`/`web_contents`/`web_answer`/`web_research`), which the previous capture approach missed entirely.

Addresses the community request: *"Could pi-claude-code-use use getAllTools() to register aliases? The current capture code misses tools registered in lifecycle hooks, including pi-web-providers."*

## Why this works

Anthropic's OAuth subscription endpoint refuses flat-named custom tools but accepts any `mcp__`-shaped name. The alias only needs to exist model-side: the pre-existing `message_end` unaliasing rewrites alias calls back to flat names **before** Pi resolves execution, so the source extension's original `execute` closure always runs. That made the jiti-captured duplicate `execute` dead code all along — aliases can be schema-only stubs built from `ToolInfo`.

## Key changes

- **Dynamic derivation**: `<server>` from `sourceInfo` (npm package name → `exa_mcp`, monorepo dir → `firecrawl`, file stem, `pi` for builtins), sanitized, `pi-` prefix stripped; deterministic collision suffixes; 128-char cap; never shadows existing tools.
- **Zero maintenance**: `COMPANIONS`, `isCompanionSource`, the capture shim, and all jiti machinery deleted (~200 lines + the `@mariozechner/jiti` dep and 4 peer deps). New extensions are covered the day they're installed.
- **Three alias passes**: `session_start`, `before_agent_start`, and `before_provider_request` (OAuth only) — the last catches tools registered by another extension's `before_agent_start` running after ours, so they work on their first turn.
- **`toolAliases` config becomes an override layer** (e.g. keep `mcp__exa__web_search`), now strictly validated: trimmed, `mcp__`-prefixed, ≤128 chars, no duplicate targets, no foreign-tool collisions, no cross-flat re-routing. Invalid entries are fully ignored with a warning.
- **Robustness** (from adversarial review): auto-activation provenance (Pi implicitly activates newly registered tools), exact-name provenance for case-only alias renames, permanent reverse routes for stale aliases after config changes, schema-refresh re-registration, order-independent payload remapping preferring the flat entry's current schema (preserving advertised `cache_control`), case-insensitive-duplicate exclusion, and kept-alias promotion in both sync branches.
- **New env var**: `PI_CLAUDE_CODE_USE_DISABLE_AUTO_ALIAS=1` disables derivation (user config still applies).

## Breaking (hence 2.0.0)

- Peer floor raised: `@earendil-works/pi-coding-agent >=0.77.0` (first release exposing `promptGuidelines` in `ToolInfo`).
- Curated alias names change to derived ones (`mcp__exa__web_search` → `mcp__exa_mcp__web_search_exa`). Session files persist flat names, so resumed sessions are unaffected; add `toolAliases` overrides to keep old names.
- `toolAliases` entries that fail validation are now ignored (previously accepted verbatim).

## Known limitations (documented)

`ToolInfo` doesn't expose `promptSnippet`, `constrainedSampling`, or custom renderers, so aliases don't carry them (execution routing unaffected). Would be resolved upstream by expanding Pi's `ToolInfo` or exposing `getToolDefinition()` on the ExtensionAPI.

## Testing

- `npm run check` (Biome + tsc) clean; `npx vitest run`: 86 package tests / 190 repo-wide, all passing.
- Manually verified via `pi -e .` with Anthropic OAuth: exa and firecrawl searches work through the derived aliases.
- Three adversarial review rounds via flowition using codex `gpt-5.6-sol` at `xhigh` effort: a 3-reviewer panel (17 findings), a verification pass (4 blockers found in the fixes), and a final sign-off pass — **approved, 0 blocking**, with Pi behavior cross-checked against current pi source.
