### PR TITLE
fix(pi-synthetic-provider): refresh fallback catalog for GLM 5.3-Flash and Qwen 3.8-27B

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4836,7 +4836,7 @@
     },
     "packages/pi-synthetic-provider": {
       "name": "@benvargas/pi-synthetic-provider",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.77.0",

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,17 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-08-31
+
 ### Added
 - Added `hf:zai-org/GLM-5.3-Flash` to the fallback catalog and the reasoning-override table with its catalog-advertised `low`, `high`, and `max` efforts. Like Kimi K3 it always reasons, so `off` is unavailable. `syn:large:text` was re-pointed to it and resolves its overrides during live discovery.
+- Added `QWEN_3_8_27B_MODEL_ID` (`hf:Qwen/Qwen3.8-27B`) to the fallback catalog and the reasoning-override table; Synthetic replaced the retired Qwen 3.6-27B route with it. The new route advertises `low`, `medium`, and `xhigh`, so `off`, `high`, and `max` are not selectable for it.
 
 ### Changed
 - Refreshed the fallback catalog against the live `always_on` catalog as of 2026-08-30. `syn:large:text` now mirrors GLM 5.3-Flash: vision-capable and $0.15/$0.50 (was text-only at $1.00/$3.00 under GLM 5.2). `syn:small:vision` and the Qwen 27B entry drop to $2.20 output (was $3.60) with Qwen 3.8-27B.
-- Renamed `QWEN_3_6_27B_MODEL_ID` to `QWEN_3_8_27B_MODEL_ID` as Synthetic replaced Qwen 3.6-27B with Qwen 3.8-27B. The new route advertises `low`, `medium`, and `xhigh`, so `off`, `high`, and `max` are no longer selectable for it.
-
-### Deprecated
-- `QWEN_3_6_27B_MODEL_ID` and `MINIMAX_M3_MODEL_ID` are deprecated but still exported with their original values. Both models are retired from the catalog, so they no longer appear in the fallback list or the reasoning-override table, but `extensions/` ships in the published package and removing the named exports outright would break deep imports. Use `QWEN_3_8_27B_MODEL_ID`, or the `syn:small:vision` permalink that Synthetic re-pointed to Qwen 3.8-27B.
 
 ### Removed
+- Removed the deprecated `KIMI_K27_CODE_MODEL_ID` export. The constant was kept after the 1.2.2 deprecation only so deep imports of `extensions/models.js` kept resolving, but the model it names is retired and fails every request. Use `KIMI_K3_MODEL_ID`, or the `syn:large:vision` permalink that Synthetic re-pointed to K3.
+- Removed the `QWEN_3_6_27B_MODEL_ID` and `MINIMAX_M3_MODEL_ID` exports. Both models are retired from Synthetic's catalog, so the constants named dead model ids that fail every request. Use `QWEN_3_8_27B_MODEL_ID`, or the `syn:small:vision` permalink that Synthetic re-pointed to Qwen 3.8-27B.
 - Removed `hf:Qwen/Qwen3.6-27B` and `hf:MiniMaxAI/MiniMax-M3` from the fallback catalog and the reasoning-override table; Synthetic retired both, and keeping them offered offline configurations that fail every request.
 
 ## [1.2.4] - 2026-08-10

--- a/packages/pi-synthetic-provider/CHANGELOG.md
+++ b/packages/pi-synthetic-provider/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `hf:zai-org/GLM-5.3-Flash` to the fallback catalog and the reasoning-override table with its catalog-advertised `low`, `high`, and `max` efforts. Like Kimi K3 it always reasons, so `off` is unavailable. `syn:large:text` was re-pointed to it and resolves its overrides during live discovery.
+
+### Changed
+- Refreshed the fallback catalog against the live `always_on` catalog as of 2026-08-30. `syn:large:text` now mirrors GLM 5.3-Flash: vision-capable and $0.15/$0.50 (was text-only at $1.00/$3.00 under GLM 5.2). `syn:small:vision` and the Qwen 27B entry drop to $2.20 output (was $3.60) with Qwen 3.8-27B.
+- Renamed `QWEN_3_6_27B_MODEL_ID` to `QWEN_3_8_27B_MODEL_ID` as Synthetic replaced Qwen 3.6-27B with Qwen 3.8-27B. The new route advertises `low`, `medium`, and `xhigh`, so `off`, `high`, and `max` are no longer selectable for it.
+
+### Deprecated
+- `QWEN_3_6_27B_MODEL_ID` and `MINIMAX_M3_MODEL_ID` are deprecated but still exported with their original values. Both models are retired from the catalog, so they no longer appear in the fallback list or the reasoning-override table, but `extensions/` ships in the published package and removing the named exports outright would break deep imports. Use `QWEN_3_8_27B_MODEL_ID`, or the `syn:small:vision` permalink that Synthetic re-pointed to Qwen 3.8-27B.
+
+### Removed
+- Removed `hf:Qwen/Qwen3.6-27B` and `hf:MiniMaxAI/MiniMax-M3` from the fallback catalog and the reasoning-override table; Synthetic retired both, and keeping them offered offline configurations that fail every request.
+
 ## [1.2.4] - 2026-08-10
 
 ### Added

--- a/packages/pi-synthetic-provider/README.md
+++ b/packages/pi-synthetic-provider/README.md
@@ -74,29 +74,29 @@ pi --provider synthetic --model hf:moonshotai/Kimi-K3
 
 Models are fetched at startup from the [Synthetic models endpoint](https://dev.synthetic.new/docs/api/models). If the startup fetch fails, times out after three seconds, or returns no supported models, the provider falls back to the following hardcoded defaults:
 
-Prices are $ per million tokens, current as of 2026-07-28.
+Prices are $ per million tokens, current as of 2026-08-30.
 
 | Model | ID | Reasoning | Vision | Context | Max Output | In / Out / Cache |
 |-------|-----|-----------|--------|---------|------------|------------------|
-| **Synthetic Large Text** | `syn:large:text` | Yes | No | 524K | 65K | 1.00 / 3.00 / 0.16 |
+| **Synthetic Large Text** | `syn:large:text` | Yes | Yes | 524K | 65K | 0.15 / 0.50 / 0.04 |
 | **Synthetic Small Text** | `syn:small:text` | Yes | No | 196K | 65K | 0.10 / 0.50 / 0.02 |
 | **Synthetic Large Vision** | `syn:large:vision` | Yes | Yes | 524K | 65K | 3.00 / 15.00 / 0.45 |
-| **Synthetic Small Vision** | `syn:small:vision` | Yes | Yes | 262K | 65K | 0.45 / 3.60 / 0.09 |
+| **Synthetic Small Vision** | `syn:small:vision` | Yes | Yes | 262K | 65K | 0.45 / 2.20 / 0.09 |
+| **GLM 5.3 Flash** | `hf:zai-org/GLM-5.3-Flash` | Yes | Yes | 524K | 65K | 0.15 / 0.50 / 0.04 |
 | **GLM 5.2** | `hf:zai-org/GLM-5.2` | Yes | No | 524K | 65K | 1.00 / 3.00 / 0.16 |
 | **GPT OSS 120B** | `hf:openai/gpt-oss-120b` | Yes | No | 131K | 65K | 0.10 / 0.10 / 0.02 |
 | **Kimi K3** | `hf:moonshotai/Kimi-K3` | Yes | Yes | 524K | 65K | 3.00 / 15.00 / 0.45 |
-| **Qwen 3.6 27B** | `hf:Qwen/Qwen3.6-27B` | Yes | Yes | 262K | 65K | 0.45 / 3.60 / 0.09 |
-| **MiniMax M3** | `hf:MiniMaxAI/MiniMax-M3` | Yes | Yes | 262K | 65K | 0.60 / 1.20 / 0.12 |
+| **Qwen 3.8 27B** | `hf:Qwen/Qwen3.8-27B` | Yes | Yes | 262K | 65K | 0.45 / 2.20 / 0.09 |
 | **GLM 4.7 Flash** | `hf:zai-org/GLM-4.7-Flash` | Yes | No | 196K | 65K | 0.10 / 0.50 / 0.02 |
 | **Nemotron 3 Super 120B** | `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | Yes | No | 262K | 65K | 0.30 / 1.00 / 0.06 |
 
-The `syn:*` ids are permalinks that Synthetic re-points as models rotate, so configs using them survive model retirements — `syn:large:vision` moved from Kimi K2.7-Code to Kimi K3 in this release. The `hf:*` ids pin a specific model and break when it is retired.
+The `syn:*` ids are permalinks that Synthetic re-points as models rotate, so configs using them survive model retirements — `syn:large:text` moved from GLM 5.2 to the vision-capable GLM 5.3-Flash, and `syn:small:vision` from Qwen 3.6 to Qwen 3.8. The `hf:*` ids pin a specific model and break when it is retired.
 
 ### Thinking levels
 
 During live discovery, the extension derives each model's exact pi thinking levels from the catalog's `reasoning_parameters.efforts`. Unsupported levels are hidden instead of being mapped onto values the route does not advertise. This works for pinned `hf:*` ids and for `syn:*` permalinks, so a permalink automatically follows its current target's effort controls when Synthetic re-points it.
 
-Kimi K3 advertises `low`, `high`, and `max`. It always reasons, so `off` is unavailable; pi sends those three values unchanged as top-level `reasoning_effort`. `/synthetic-models` shows the advertised values in the selected model details.
+Kimi K3 and GLM 5.3-Flash advertise `low`, `high`, and `max`. They always reason, so `off` is unavailable; pi sends those values unchanged as top-level `reasoning_effort`. Qwen 3.8-27B similarly has no `none` and tops out at `xhigh`. `/synthetic-models` shows the advertised values in the selected model details.
 
 If the catalog request fails, pinned fallback models use hardcoded snapshots of their last advertised effort lists. Offline permalinks deliberately emit no `reasoning_effort`: without a live row there is no trustworthy way to know what an alias currently targets. Pi still displays its generic `off` through `high` levels for those fallback aliases because they declare `reasoning: true`, but the selections have no effect on the request.
 

--- a/packages/pi-synthetic-provider/__tests__/helpers.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/helpers.test.ts
@@ -27,10 +27,10 @@ describe("pi-synthetic-provider helpers", () => {
 			"syn:large:vision",
 			"syn:small:vision",
 			"hf:openai/gpt-oss-120b",
+			"hf:zai-org/GLM-5.3-Flash",
 			"hf:zai-org/GLM-5.2",
 			"hf:moonshotai/Kimi-K3",
-			"hf:Qwen/Qwen3.6-27B",
-			"hf:MiniMaxAI/MiniMax-M3",
+			"hf:Qwen/Qwen3.8-27B",
 			"hf:zai-org/GLM-4.7-Flash",
 			"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
 		]);
@@ -41,6 +41,8 @@ describe("pi-synthetic-provider helpers", () => {
 			"hf:moonshotai/Kimi-K2.7-Code",
 			"hf:zai-org/GLM-4.7",
 			"hf:Qwen/Qwen3.5-397B-A17B",
+			"hf:Qwen/Qwen3.6-27B",
+			"hf:MiniMaxAI/MiniMax-M3",
 		]) {
 			expect(modelIds).not.toContain(staleId);
 		}
@@ -49,8 +51,10 @@ describe("pi-synthetic-provider helpers", () => {
 			reasoning: true,
 			maxTokens: 65536,
 		});
-		expect(models.find((model) => model.id === "hf:MiniMaxAI/MiniMax-M3")).toMatchObject({
-			contextWindow: 262144,
+		expect(models.find((model) => model.id === "hf:zai-org/GLM-5.3-Flash")).toMatchObject({
+			contextWindow: 524288,
+			input: ["text", "image"],
+			cost: { input: 0.15, output: 0.5, cacheRead: 0.04 },
 		});
 		expect(models.find((model) => model.id === "hf:moonshotai/Kimi-K3")).toMatchObject({
 			contextWindow: 524288,
@@ -62,23 +66,29 @@ describe("pi-synthetic-provider helpers", () => {
 			contextWindow: 524288,
 			cost: { input: 3, output: 15, cacheRead: 0.45 },
 		});
+		// syn:large:text was re-pointed from GLM 5.2 to the vision-capable GLM 5.3-Flash.
+		expect(models.find((model) => model.id === "syn:large:text")).toMatchObject({
+			contextWindow: 524288,
+			input: ["text", "image"],
+			cost: { input: 0.15, output: 0.5, cacheRead: 0.04 },
+		});
 	});
 
 	it("matches the live catalog price for every fallback model", () => {
 		// Exact expected values, not merely cacheRead < input: the bug being guarded
 		// against set cacheRead equal to input, and a too-low wrong value would still
-		// satisfy an inequality. Sourced from input_cache_reads in the 2026-07-28
-		// authenticated catalog pull.
+		// satisfy an inequality. Sourced from input_cache_reads in the 2026-08-30
+		// catalog pull.
 		const expected: Record<string, { input: number; output: number; cacheRead: number }> = {
-			"syn:large:text": { input: 1, output: 3, cacheRead: 0.16 },
+			"syn:large:text": { input: 0.15, output: 0.5, cacheRead: 0.04 },
 			"syn:small:text": { input: 0.1, output: 0.5, cacheRead: 0.02 },
 			"syn:large:vision": { input: 3, output: 15, cacheRead: 0.45 },
-			"syn:small:vision": { input: 0.45, output: 3.6, cacheRead: 0.09 },
+			"syn:small:vision": { input: 0.45, output: 2.2, cacheRead: 0.09 },
 			"hf:openai/gpt-oss-120b": { input: 0.1, output: 0.1, cacheRead: 0.02 },
+			"hf:zai-org/GLM-5.3-Flash": { input: 0.15, output: 0.5, cacheRead: 0.04 },
 			"hf:zai-org/GLM-5.2": { input: 1, output: 3, cacheRead: 0.16 },
 			"hf:moonshotai/Kimi-K3": { input: 3, output: 15, cacheRead: 0.45 },
-			"hf:Qwen/Qwen3.6-27B": { input: 0.45, output: 3.6, cacheRead: 0.09 },
-			"hf:MiniMaxAI/MiniMax-M3": { input: 0.6, output: 1.2, cacheRead: 0.12 },
+			"hf:Qwen/Qwen3.8-27B": { input: 0.45, output: 2.2, cacheRead: 0.09 },
 			"hf:zai-org/GLM-4.7-Flash": { input: 0.1, output: 0.5, cacheRead: 0.02 },
 			"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": { input: 0.3, output: 1, cacheRead: 0.06 },
 		};
@@ -107,21 +117,27 @@ describe("pi-synthetic-provider helpers", () => {
 			xhigh: null,
 			max: null,
 		};
+		const lowHighMax = {
+			off: null,
+			minimal: null,
+			low: "low",
+			medium: null,
+			high: "high",
+			xhigh: null,
+			max: "max",
+		};
 		const reasoningModels = [
+			["hf:zai-org/GLM-5.3-Flash", lowHighMax],
 			[
 				"hf:zai-org/GLM-5.2",
 				{ off: "none", minimal: null, low: null, medium: null, high: "high", xhigh: null, max: "max" },
 			],
 			["hf:zai-org/GLM-4.7-Flash", noneLowMediumHigh],
 			["hf:openai/gpt-oss-120b", noneLowMediumHigh],
+			["hf:moonshotai/Kimi-K3", lowHighMax],
 			[
-				"hf:moonshotai/Kimi-K3",
-				{ off: null, minimal: null, low: "low", medium: null, high: "high", xhigh: null, max: "max" },
-			],
-			["hf:Qwen/Qwen3.6-27B", noneLowMediumHigh],
-			[
-				"hf:MiniMaxAI/MiniMax-M3",
-				{ off: null, minimal: null, low: null, medium: "medium", high: null, xhigh: null, max: null },
+				"hf:Qwen/Qwen3.8-27B",
+				{ off: null, minimal: null, low: "low", medium: "medium", high: null, xhigh: "xhigh", max: null },
 			],
 			["hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4", noneLowMediumHigh],
 		] as const;

--- a/packages/pi-synthetic-provider/__tests__/index.test.ts
+++ b/packages/pi-synthetic-provider/__tests__/index.test.ts
@@ -3,9 +3,9 @@ import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-codin
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import syntheticProvider, { getFallbackModels } from "../extensions/index.js";
 
+const GLM_5_3_FLASH_MODEL_ID = "hf:zai-org/GLM-5.3-Flash";
 const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
 const KIMI_K3_MODEL_ID = "hf:moonshotai/Kimi-K3";
-const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
 const NONE_LOW_MEDIUM_HIGH_MAP = {
 	off: "none",
 	minimal: null,
@@ -15,7 +15,17 @@ const NONE_LOW_MEDIUM_HIGH_MAP = {
 	xhigh: null,
 	max: null,
 } as const;
+const LOW_HIGH_MAX_MAP = {
+	off: null,
+	minimal: null,
+	low: "low",
+	medium: null,
+	high: "high",
+	xhigh: null,
+	max: "max",
+} as const;
 const REASONING_MODEL_MAPS = {
+	[GLM_5_3_FLASH_MODEL_ID]: LOW_HIGH_MAX_MAP,
 	[GLM_5_2_MODEL_ID]: {
 		off: "none",
 		minimal: null,
@@ -27,34 +37,25 @@ const REASONING_MODEL_MAPS = {
 	},
 	"hf:zai-org/GLM-4.7-Flash": NONE_LOW_MEDIUM_HIGH_MAP,
 	"hf:openai/gpt-oss-120b": NONE_LOW_MEDIUM_HIGH_MAP,
-	[KIMI_K3_MODEL_ID]: {
+	[KIMI_K3_MODEL_ID]: LOW_HIGH_MAX_MAP,
+	"hf:Qwen/Qwen3.8-27B": {
 		off: null,
 		minimal: null,
 		low: "low",
-		medium: null,
-		high: "high",
-		xhigh: null,
-		max: "max",
-	},
-	"hf:Qwen/Qwen3.6-27B": NONE_LOW_MEDIUM_HIGH_MAP,
-	[MINIMAX_M3_MODEL_ID]: {
-		off: null,
-		minimal: null,
-		low: null,
 		medium: "medium",
 		high: null,
-		xhigh: null,
+		xhigh: "xhigh",
 		max: null,
 	},
 	"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": NONE_LOW_MEDIUM_HIGH_MAP,
 } as const;
 const REASONING_MODEL_EFFORTS = {
+	[GLM_5_3_FLASH_MODEL_ID]: ["low", "high", "max"],
 	[GLM_5_2_MODEL_ID]: ["none", "high", "max"],
 	"hf:zai-org/GLM-4.7-Flash": ["none", "low", "medium", "high"],
 	"hf:openai/gpt-oss-120b": ["none", "low", "medium", "high"],
 	[KIMI_K3_MODEL_ID]: ["low", "high", "max"],
-	"hf:Qwen/Qwen3.6-27B": ["none", "low", "medium", "high"],
-	[MINIMAX_M3_MODEL_ID]: ["medium"],
+	"hf:Qwen/Qwen3.8-27B": ["low", "medium", "xhigh"],
 	"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": ["none", "low", "medium", "high"],
 } as const;
 const REASONING_MODEL_IDS = Object.keys(REASONING_MODEL_MAPS);
@@ -246,10 +247,10 @@ describe("pi-synthetic-provider", () => {
 
 	it("resolves syn:* permalink overrides through the catalog target when effort metadata is absent", async () => {
 		const permalinks = [
-			["syn:large:text", "zai-org/GLM-5.2"],
+			["syn:large:text", "zai-org/GLM-5.3-Flash"],
 			["syn:small:text", "zai-org/GLM-4.7-Flash"],
 			["syn:large:vision", "moonshotai/Kimi-K3"],
-			["syn:small:vision", "Qwen/Qwen3.6-27B"],
+			["syn:small:vision", "Qwen/Qwen3.8-27B"],
 		] as const;
 		vi.stubGlobal(
 			"fetch",
@@ -290,7 +291,7 @@ describe("pi-synthetic-provider", () => {
 		const rows = [
 			{ id: "syn:large:vision", hugging_face_id: "moonshotai/Kimi-K9", supported_features: ["tools", "reasoning"] },
 			{ id: "syn:large:text", supported_features: ["tools", "reasoning"] },
-			{ id: "syn:small:vision", hugging_face_id: "hf:Qwen/Qwen3.6-27B", supported_features: ["tools", "reasoning"] },
+			{ id: "syn:small:vision", hugging_face_id: "hf:Qwen/Qwen3.8-27B", supported_features: ["tools", "reasoning"] },
 			{ id: "syn:small:text", hugging_face_id: "zai-org/GLM-4.7-Flash", supported_features: ["tools"] },
 		];
 		vi.stubGlobal(

--- a/packages/pi-synthetic-provider/extensions/index.ts
+++ b/packages/pi-synthetic-provider/extensions/index.ts
@@ -32,10 +32,10 @@
  *   pi /model
  *
  *   # Use specific model
- *   pi --model synthetic/hf:moonshotai/Kimi-K2.6
+ *   pi --model synthetic/hf:moonshotai/Kimi-K3
  *
  *   # Use default model
- *   pi --provider synthetic --model hf:moonshotai/Kimi-K2.6
+ *   pi --provider synthetic --model hf:moonshotai/Kimi-K3
  *
  * Note: Models are fetched dynamically from the API during startup and refreshed
  * at session start, so the available models list stays current.

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -15,34 +15,6 @@ export const KIMI_K3_MODEL_ID = "hf:moonshotai/Kimi-K3";
 export const QWEN_3_8_27B_MODEL_ID = "hf:Qwen/Qwen3.8-27B";
 export const NEMOTRON_3_SUPER_MODEL_ID = "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4";
 
-/**
- * @deprecated Synthetic retired this model alongside the Kimi K3 launch, so it no
- * longer appears in the catalog, in the fallback list, or in the reasoning-effort
- * table. The constant is retained only so deep imports of `extensions/models.js`
- * keep resolving — `extensions/` ships in the published package. Use
- * {@link KIMI_K3_MODEL_ID}, or the `syn:large:vision` permalink, which Synthetic
- * re-pointed from this model to K3.
- */
-export const KIMI_K27_CODE_MODEL_ID = "hf:moonshotai/Kimi-K2.7-Code";
-
-/**
- * @deprecated Synthetic retired this model alongside the Qwen 3.8-27B launch, so
- * it no longer appears in the catalog, in the fallback list, or in the
- * reasoning-effort table. The constant is retained only so deep imports of
- * `extensions/models.js` keep resolving — `extensions/` ships in the published
- * package. Use {@link QWEN_3_8_27B_MODEL_ID}, or the `syn:small:vision`
- * permalink, which Synthetic re-pointed from this model to Qwen 3.8-27B.
- */
-export const QWEN_3_6_27B_MODEL_ID = "hf:Qwen/Qwen3.6-27B";
-
-/**
- * @deprecated Synthetic retired this model, so it no longer appears in the
- * catalog, in the fallback list, or in the reasoning-effort table. The constant
- * is retained only so deep imports of `extensions/models.js` keep resolving —
- * `extensions/` ships in the published package.
- */
-export const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
-
 type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
 	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
 type SyntheticThinkingLevel = keyof NonNullable<ProviderModelConfig["thinkingLevelMap"]>;

--- a/packages/pi-synthetic-provider/extensions/models.ts
+++ b/packages/pi-synthetic-provider/extensions/models.ts
@@ -7,12 +7,12 @@ import { SYNTHETIC_COMPAT, SYNTHETIC_MODELS_ENDPOINT } from "./config.js";
 import { parsePrice } from "./formatting.js";
 import type { SyntheticModel, SyntheticModelsResponse } from "./types.js";
 
+export const GLM_5_3_FLASH_MODEL_ID = "hf:zai-org/GLM-5.3-Flash";
 export const GLM_5_2_MODEL_ID = "hf:zai-org/GLM-5.2";
 export const GLM_4_7_FLASH_MODEL_ID = "hf:zai-org/GLM-4.7-Flash";
 export const GPT_OSS_120B_MODEL_ID = "hf:openai/gpt-oss-120b";
 export const KIMI_K3_MODEL_ID = "hf:moonshotai/Kimi-K3";
-export const QWEN_3_6_27B_MODEL_ID = "hf:Qwen/Qwen3.6-27B";
-export const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
+export const QWEN_3_8_27B_MODEL_ID = "hf:Qwen/Qwen3.8-27B";
 export const NEMOTRON_3_SUPER_MODEL_ID = "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4";
 
 /**
@@ -24,6 +24,24 @@ export const NEMOTRON_3_SUPER_MODEL_ID = "hf:nvidia/NVIDIA-Nemotron-3-Super-120B
  * re-pointed from this model to K3.
  */
 export const KIMI_K27_CODE_MODEL_ID = "hf:moonshotai/Kimi-K2.7-Code";
+
+/**
+ * @deprecated Synthetic retired this model alongside the Qwen 3.8-27B launch, so
+ * it no longer appears in the catalog, in the fallback list, or in the
+ * reasoning-effort table. The constant is retained only so deep imports of
+ * `extensions/models.js` keep resolving — `extensions/` ships in the published
+ * package. Use {@link QWEN_3_8_27B_MODEL_ID}, or the `syn:small:vision`
+ * permalink, which Synthetic re-pointed from this model to Qwen 3.8-27B.
+ */
+export const QWEN_3_6_27B_MODEL_ID = "hf:Qwen/Qwen3.6-27B";
+
+/**
+ * @deprecated Synthetic retired this model, so it no longer appears in the
+ * catalog, in the fallback list, or in the reasoning-effort table. The constant
+ * is retained only so deep imports of `extensions/models.js` keep resolving —
+ * `extensions/` ships in the published package.
+ */
+export const MINIMAX_M3_MODEL_ID = "hf:MiniMaxAI/MiniMax-M3";
 
 type SyntheticModelOverrides = Pick<ProviderModelConfig, "compat"> &
 	Partial<Pick<ProviderModelConfig, "reasoning" | "thinkingLevelMap">>;
@@ -80,16 +98,16 @@ function createReasoningOverrides(efforts: readonly string[]): SyntheticModelOve
  * be fetched. Values mirror the authenticated catalog's
  * `reasoning_parameters.efforts`; live rows override these snapshots.
  *
- * Kimi K3 always reasons and only accepts `low`, `high`, and `max`, so `off` is
- * deliberately unavailable. MiniMax M3 is no longer in the current catalog; its
- * last verified `medium`-only control remains for the offline fallback entry.
+ * Kimi K3 and GLM 5.3-Flash always reason and only accept `low`, `high`, and
+ * `max`, so `off` is deliberately unavailable. Qwen 3.8-27B has no `none` either
+ * and tops out at `xhigh`, so `off`, `high`, and `max` are unavailable.
  */
+const GLM_5_3_FLASH_REASONING_OVERRIDES = createReasoningOverrides(["low", "high", "max"]);
 const GLM_5_2_REASONING_OVERRIDES = createReasoningOverrides(["none", "high", "max"]);
 const GLM_4_7_FLASH_REASONING_OVERRIDES = createReasoningOverrides(["none", "low", "medium", "high"]);
 const GPT_OSS_120B_REASONING_OVERRIDES = createReasoningOverrides(["none", "low", "medium", "high"]);
 const KIMI_K3_REASONING_OVERRIDES = createReasoningOverrides(["low", "high", "max"]);
-const QWEN_3_6_27B_REASONING_OVERRIDES = createReasoningOverrides(["none", "low", "medium", "high"]);
-const MINIMAX_M3_REASONING_OVERRIDES = createReasoningOverrides(["medium"]);
+const QWEN_3_8_27B_REASONING_OVERRIDES = createReasoningOverrides(["low", "medium", "xhigh"]);
 const NEMOTRON_3_SUPER_REASONING_OVERRIDES = createReasoningOverrides(["none", "low", "medium", "high"]);
 
 /**
@@ -98,12 +116,12 @@ const NEMOTRON_3_SUPER_REASONING_OVERRIDES = createReasoningOverrides(["none", "
  * would return a truthy non-override and be spread into a model config.
  */
 const REASONING_OVERRIDES = new Map<string, SyntheticModelOverrides>([
+	[GLM_5_3_FLASH_MODEL_ID, GLM_5_3_FLASH_REASONING_OVERRIDES],
 	[GLM_5_2_MODEL_ID, GLM_5_2_REASONING_OVERRIDES],
 	[GLM_4_7_FLASH_MODEL_ID, GLM_4_7_FLASH_REASONING_OVERRIDES],
 	[GPT_OSS_120B_MODEL_ID, GPT_OSS_120B_REASONING_OVERRIDES],
 	[KIMI_K3_MODEL_ID, KIMI_K3_REASONING_OVERRIDES],
-	[QWEN_3_6_27B_MODEL_ID, QWEN_3_6_27B_REASONING_OVERRIDES],
-	[MINIMAX_M3_MODEL_ID, MINIMAX_M3_REASONING_OVERRIDES],
+	[QWEN_3_8_27B_MODEL_ID, QWEN_3_8_27B_REASONING_OVERRIDES],
 	[NEMOTRON_3_SUPER_MODEL_ID, NEMOTRON_3_SUPER_REASONING_OVERRIDES],
 ]);
 
@@ -284,12 +302,13 @@ export async function fetchSyntheticModels(
 /**
  * Fallback models if API fetch fails.
  * Data sourced from: authenticated GET https://api.synthetic.new/openai/v1/models
- * Model metadata last updated: 2026-07-28
- * Reasoning efforts last updated: 2026-08-10
+ * Model metadata last updated: 2026-08-30
+ * Reasoning efforts last updated: 2026-08-30
  *
  * Mirrors the live `always_on` catalog. The `syn:*` permalinks are stable
- * aliases Synthetic re-points as models rotate; `syn:large:vision` now resolves
- * to Kimi K3 (was Kimi K2.7-Code, since retired) and `syn:large:text` to GLM 5.2.
+ * aliases Synthetic re-points as models rotate: `syn:large:vision` resolves to
+ * Kimi K3, `syn:large:text` to GLM 5.3-Flash, `syn:small:text` to GLM
+ * 4.7-Flash, and `syn:small:vision` to Qwen 3.8-27B.
  *
  * Pricing format: $/million tokens. `cacheRead` tracks the catalog's
  * `input_cache_reads` rate, which is well below the input rate on every model.
@@ -307,11 +326,11 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			id: "syn:large:text",
 			name: "syn:large:text",
 			reasoning: true,
-			input: ["text"],
+			input: ["text", "image"],
 			cost: {
-				input: 1,
-				output: 3,
-				cacheRead: 0.16,
+				input: 0.15,
+				output: 0.5,
+				cacheRead: 0.04,
 				cacheWrite: 0,
 			},
 			contextWindow: 524288,
@@ -355,7 +374,7 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			input: ["text", "image"],
 			cost: {
 				input: 0.45,
-				output: 3.6,
+				output: 2.2,
 				cacheRead: 0.09,
 				cacheWrite: 0,
 			},
@@ -377,6 +396,21 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			contextWindow: 131072,
 			maxTokens: 65536,
 			...getSyntheticModelOverrides(GPT_OSS_120B_MODEL_ID),
+		},
+		{
+			id: GLM_5_3_FLASH_MODEL_ID,
+			name: "zai-org/GLM-5.3-Flash",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0.15,
+				output: 0.5,
+				cacheRead: 0.04,
+				cacheWrite: 0,
+			},
+			contextWindow: 524288,
+			maxTokens: 65536,
+			...getSyntheticModelOverrides(GLM_5_3_FLASH_MODEL_ID),
 		},
 		{
 			id: GLM_5_2_MODEL_ID,
@@ -409,34 +443,19 @@ export function getFallbackModels(): ProviderModelConfig[] {
 			...getSyntheticModelOverrides(KIMI_K3_MODEL_ID),
 		},
 		{
-			id: QWEN_3_6_27B_MODEL_ID,
-			name: "Qwen/Qwen3.6-27B",
+			id: QWEN_3_8_27B_MODEL_ID,
+			name: "Qwen/Qwen3.8-27B",
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
 				input: 0.45,
-				output: 3.6,
+				output: 2.2,
 				cacheRead: 0.09,
 				cacheWrite: 0,
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-			...getSyntheticModelOverrides(QWEN_3_6_27B_MODEL_ID),
-		},
-		{
-			id: MINIMAX_M3_MODEL_ID,
-			name: "MiniMaxAI/MiniMax-M3",
-			reasoning: true,
-			input: ["text", "image"],
-			cost: {
-				input: 0.6,
-				output: 1.2,
-				cacheRead: 0.12,
-				cacheWrite: 0,
-			},
-			contextWindow: 262144,
-			maxTokens: 65536,
-			...getSyntheticModelOverrides(MINIMAX_M3_MODEL_ID),
+			...getSyntheticModelOverrides(QWEN_3_8_27B_MODEL_ID),
 		},
 		{
 			id: GLM_4_7_FLASH_MODEL_ID,

--- a/packages/pi-synthetic-provider/package.json
+++ b/packages/pi-synthetic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benvargas/pi-synthetic-provider",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Synthetic (synthetic.new) model provider for pi - Dynamic model fetching with reasoning, vision, and tools support",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

Refreshes pi-synthetic-provider's hardcoded fallback catalog and reasoning-effort snapshots against Synthetic's live `GET /openai/v1/models` catalog (`always_on` rows as of 2026-08-30). The API itself is unchanged — same models-endpoint schema including `reasoning_parameters.efforts`, and `/v2/quotas` behaves as before — so the dynamic discovery path needed no changes; only the offline snapshot, docs, and tests drifted. All catalog data was re-verified against a live, unauthenticated pull after the final commit.

## What changed

- Added `hf:zai-org/GLM-5.3-Flash` to the fallback catalog and reasoning-override table: vision-capable, $0.15/$0.50/$0.04 per million, efforts `low`/`high`/`max` (always reasons, so no `off`).
- `syn:large:text` was re-pointed from GLM 5.2 to GLM 5.3-Flash, so its fallback entry is now vision-capable at $0.15/$0.50 (was text-only at $1.00/$3.00).
- Replaced retired `hf:Qwen/Qwen3.6-27B` with `hf:Qwen/Qwen3.8-27B`: $2.20 output (was $3.60), efforts now `low`/`medium`/`xhigh`, so `off`, `high`, and `max` are no longer selectable; `syn:small:vision` follows.
- Removed retired `hf:MiniMaxAI/MiniMax-M3` from the fallback list and override table so offline sessions no longer offer a model that fails every request.
- Removed the retired model-id constant exports `KIMI_K27_CODE_MODEL_ID`, `QWEN_3_6_27B_MODEL_ID`, and `MINIMAX_M3_MODEL_ID` from `extensions/models.js` (follow-up commit 5ad31e2). They named catalog-dead ids that fail every request; deep-import consumers should switch to `KIMI_K3_MODEL_ID` / `QWEN_3_8_27B_MODEL_ID`, or the `syn:large:vision` / `syn:small:vision` permalinks. This departs from the 1.2.2 deprecation-keep precedent by maintainer decision and is documented in the 1.2.5 CHANGELOG entry (Removed).
- Version bumped 1.2.4 → 1.2.5 (`package.json` + lockfile) with a dated `[1.2.5] - 2026-08-31` CHANGELOG section — the repo has no release workflow, so the bump ships in the PR, matching prior convention (e.g. `chore(pi-synthetic-provider): bump version to 1.2.2 (#30)`).
- README model table and thinking-level notes refreshed.

## Verification

- `npx vitest run packages/pi-synthetic-provider` — 59/59 pass.
- Repo-wide `npm run test` — 284/284 across 17 files; `npm run check:ci` (biome + tsc) passes on both `main` and this branch; CI green on the head commit.
- Machine-checked the fallback list field-for-field against a live unauthenticated pull of the `always_on` catalog: ids, `hugging_face_id` targets of the four `syn:*` permalinks, input modalities, all four cost fields, and each pinned model's `reasoning_parameters.efforts` / derived `thinkingLevelMap` all match. Confirmed `MiniMax-M3` and `Qwen 3.6-27B` are absent from the live catalog.
- Only context windows / max output tokens remain unverifiable from the endpoint (catalog returns `null` for `context_window_tokens`/`max_output_tokens`); these carry over unchanged from the 1.2.4 snapshot, and GLM 5.3-Flash's values mirror its `syn:large:text` anchor.