### PR TITLE
pi-claude-code-use: keep renamed tool calls in conversation history identical on every request to stop resending whole conversations

### DIFF
--- a/packages/pi-claude-code-use/__tests__/index.test.ts
+++ b/packages/pi-claude-code-use/__tests__/index.test.ts
@@ -445,6 +445,47 @@ describe("pi-claude-code-use", () => {
 		]);
 	});
 
+	it("keeps historical tool_use names stable when a later payload stops advertising the alias", () => {
+		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
+		const history = [
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_1", name: "web_search_exa", input: {} }],
+			},
+		];
+
+		// Turn 1 advertises both the flat tool and its alias.
+		const first = _test.transformPayload(
+			{
+				messages: history,
+				tools: [
+					{ name: "web_search_exa", input_schema: {} },
+					{ name: "mcp__exa_mcp__web_search_exa", input_schema: {} },
+				],
+			},
+			false,
+		);
+
+		// Turn 2 advertises neither (deferred tool splitting drops them from this
+		// payload). The identical history must still serialize identically, or the
+		// prompt-cache prefix breaks at the first tool call on every turn.
+		const second = _test.transformPayload(
+			{
+				messages: history,
+				tools: [{ name: "Read", input_schema: {} }],
+			},
+			false,
+		);
+
+		expect(second.messages).toEqual(first.messages);
+		expect(second.messages).toEqual([
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "toolu_1", name: "mcp__exa_mcp__web_search_exa", input: {} }],
+			},
+		]);
+	});
+
 	it("preserves tool_use names when no MCP alias survives filtering", () => {
 		_test.refreshAliasMap([], [["web_search_exa", "mcp__exa_mcp__web_search_exa"]]);
 		const result = _test.transformPayload(

--- a/packages/pi-claude-code-use/extensions/index.ts
+++ b/packages/pi-claude-code-use/extensions/index.ts
@@ -289,9 +289,16 @@ function lower(name: string | undefined): string {
 	return (name ?? "").trim().toLowerCase();
 }
 
+// Aliases that have been advertised at least once in this session. Used to keep
+// historical `tool_use` rewriting stable across turns; see remapMessageToolNames.
+const everAdvertisedAliases = new Set<string>();
+
 function refreshAliasMap(userToolAliases: ToolAliasPair[], derivedPairs: ToolAliasPair[] = []): void {
 	FLAT_TO_MCP.clear();
 	MCP_TO_FLAT.clear();
+	// The alias map is being rebuilt, so observations made against the previous
+	// map no longer describe it.
+	everAdvertisedAliases.clear();
 	for (const [flat, mcp] of derivedPairs) {
 		FLAT_TO_MCP.set(lower(flat), mcp);
 		MCP_TO_FLAT.set(lower(mcp), flat);
@@ -453,6 +460,12 @@ function filterAndRemapTools(tools: unknown[] | undefined, disableFilter: boolea
 	if (!Array.isArray(tools)) return tools;
 
 	const advertised = collectToolNames(tools);
+	// Remember advertised aliases for the life of the session so historical
+	// tool_use rewriting cannot flip when a later payload omits them.
+	for (const mcpAlias of FLAT_TO_MCP.values()) {
+		const aliasLc = lower(mcpAlias);
+		if (advertised.has(aliasLc)) everAdvertisedAliases.add(aliasLc);
+	}
 	const toolsByName = collectToolsByName(tools);
 	const emitted = new Set<string>();
 	const result: unknown[] = [];
@@ -560,13 +573,32 @@ function remapToolChoice(
 	return undefined;
 }
 
-function remapMessageToolNames(messages: unknown[], survivingNames: Map<string, string>): unknown[] {
+// Historical `tool_use` names must serialize identically on every request, or
+// the Anthropic prompt cache breaks at the first tool call and the whole
+// conversation is written instead of read on every turn.
+//
+// `survivingNames` is rebuilt from the tools advertised in the *current*
+// payload, and that set is not stable across turns: deferred tool splitting and
+// mid-turn alias registration change which tools appear in any single request.
+// Gating history on it renamed the same past call to `mcp__server__tool` on one
+// turn and back to its flat name on the next, invalidating the cached prefix
+// every time. Measured in one 326-turn session: cacheRead pinned at 19,546
+// tokens (the static system+tools block) while 50.1M tokens were written
+// against 6.25M read.
+//
+// The fix is to decide from session-scoped state instead: an alias qualifies
+// once it has been registered by this extension or advertised at any point in
+// the session. Both signals only grow, so a call that was renamed on one turn
+// stays renamed on every later turn and the prefix keeps matching.
+function remapMessageToolNames(messages: unknown[], _survivingNames: Map<string, string>): unknown[] {
 	let anyChanged = false;
 	const result = messages.map((msg) => {
 		if (!isPlainObject(msg) || !Array.isArray(msg.content)) return msg;
 		const content = remapBlockNames(msg.content, "tool_use", (n) => {
 			const alias = FLAT_TO_MCP.get(lower(n));
-			return alias && survivingNames.has(lower(alias)) ? alias : undefined;
+			if (!alias) return undefined;
+			const aliasLc = lower(alias);
+			return registeredMcpAliases.has(aliasLc) || everAdvertisedAliases.has(aliasLc) ? alias : undefined;
 		});
 		if (content === msg.content) return msg;
 		anyChanged = true;


### PR DESCRIPTION
## Purpose

When this extension renames a tool to its MCP-style alias, it also rewrites the names of tool calls already sitting in the conversation history. That rewrite was decided from the tool list attached to the request being sent, and that list legitimately varies from one request to the next, so the same past tool call was sent under two different names on alternating turns. Anthropic's prompt cache only reuses a conversation whose earlier content is byte-for-byte identical, so the name flip made every request re-send the entire conversation as new cached content instead of reusing what was already stored.

## Summary of changes

- Decide the historical rename from state that lasts for the whole session: a tool alias qualifies once this extension has registered it, or once it has appeared in any request during the session. Both records only grow, so the same history is always sent the same way.
- Add a regression test covering the exact trigger: one request that lists the alias, then a later request that does not, with the conversation history required to come out identical both times.

## Changes to review

- Confirm the session-long record is cleared at the right moment. It resets when the alias map is rebuilt, which keeps a rebuilt map from inheriting stale observations, at the cost of one possible rename flip on the turn a rebuild happens.
- Confirm that renaming a past tool call whose tool is absent from the current request is acceptable, since that is the behavior that makes the conversation stable.

<!-- pi-sig v=1 sig=pi-peccxfhaaf act=author at=2026-09-10T17:38:01Z machine=albot agent=main model=claude-opus-5 sid=01a053d5-a3ac-77a9-94bd-7fbe03796f04 cwd=/Users/albert/Repositories/pi-packages -->
